### PR TITLE
add anonymous telemetry

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var Version = "dev"
 
 func init() {
 	redis.Version = Version
+	sql.Version = Version
 }
 
 func main() {

--- a/redis/cmd.go
+++ b/redis/cmd.go
@@ -290,7 +290,7 @@ Examples:
 	// Start telemetry client
 	var telemetryCancel context.CancelFunc
 	var telemetryDone chan struct{}
-	if telemetryEnabled {
+	if telemetryEnabled && activeRuntime != nil {
 		telCtx, cancel := context.WithCancel(context.Background())
 		telemetryCancel = cancel
 		nodeID := fmt.Sprintf("%x", uint64(activeRuntime.Engine.NodeID()))
@@ -315,7 +315,7 @@ Examples:
 			},
 		})
 		telemetryDone = make(chan struct{})
-		go func() { tc.Run(telCtx); close(telemetryDone) }()
+		go func() { defer close(telemetryDone); tc.Run(telCtx) }()
 	}
 
 	// Handle signals

--- a/redis/cmd.go
+++ b/redis/cmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/swytchdb/cache/beacon"
 	"github.com/swytchdb/cache/metrics"
 	"github.com/swytchdb/cache/redis/shared"
+	"github.com/swytchdb/cache/telemetry"
 	"github.com/swytchdb/cache/tracing"
 )
 
@@ -83,6 +84,10 @@ func Main(args []string) {
 	otelEndpoint := fs.String("otel-endpoint", "", "OTLP HTTP endpoint for tracing (e.g., localhost:4318). Empty = disabled")
 	otelInsecure := fs.Bool("otel-insecure", false, "Use HTTP instead of HTTPS for OTLP endpoint")
 
+	// Telemetry
+	noTelemetry := fs.Bool("no-telemetry", false, "Disable anonymous usage telemetry")
+	inviteMe := fs.String("invite-me", "", "Register as an early adopter with your email (overrides --no-telemetry)")
+
 	// Effects-specific flags (only present in effects builds)
 	effectsCfg := RegisterEffectsFlags(fs)
 
@@ -115,6 +120,10 @@ TLS options:
   --tls-ca-cert-file=<path> Path to CA certificate for client verification (mTLS)
   --tls-min-version=<ver>   Minimum TLS version: 1.0, 1.1, 1.2, 1.3 (default: 1.2)
 
+Telemetry:
+  --no-telemetry            Disable anonymous usage telemetry
+  --invite-me=<email>       Register as an early adopter (overrides --no-telemetry)
+
 Swytch extensions:
   --pprof=<addr>            Enable pprof profiling on this address (e.g., localhost:6060)
   --metrics-port=<port>     Enable Prometheus metrics on this port (e.g., 9090)
@@ -144,6 +153,9 @@ Examples:
 		fmt.Printf("swytch redis %s\n", Version)
 		return
 	}
+
+	telemetryEnabled := !*noTelemetry || *inviteMe != ""
+	telemetry.PrintBanner(telemetryEnabled, *inviteMe)
 
 	// Configure structured logging
 	var logLevel slog.Level
@@ -265,13 +277,45 @@ Examples:
 	}
 
 	// Start license heartbeat if license is provided
-	// Start metrics server if enabled (before signal handler so we can shut it down)
+	// Metrics adapter is always created (lightweight wrapper); metrics
+	// server only starts when --metrics-port is set.
+	adapter := NewMetricsAdapter(server.Stats(), server.Handler(), maxMemory)
 	var metricsServer *metrics.Server
 	if *metricsPort > 0 {
-		adapter := NewMetricsAdapter(server.Stats(), server.Handler(), maxMemory)
 		metricsServer = metrics.NewServer(adapter, *metricsPort)
 		metricsServer.StartAsync()
 		slog.Info("Prometheus metrics server started", "port", *metricsPort, "path", "/metrics")
+	}
+
+	// Start telemetry client
+	var telemetryCancel context.CancelFunc
+	var telemetryDone chan struct{}
+	if telemetryEnabled {
+		telCtx, cancel := context.WithCancel(context.Background())
+		telemetryCancel = cancel
+		nodeID := fmt.Sprintf("%x", uint64(activeRuntime.Engine.NodeID()))
+		tc := telemetry.New(telemetry.Config{
+			NodeID:       nodeID,
+			Version:      Version,
+			Features:     "redis",
+			AdopterEmail: *inviteMe,
+			StatsFunc: func() telemetry.HeartbeatStats {
+				nodes := 1
+				if activeRuntime != nil && activeRuntime.PeerManager != nil {
+					nodes = len(activeRuntime.PeerManager.PeerIDs()) + 1
+				}
+				return telemetry.HeartbeatStats{
+					Nodes:         nodes,
+					UptimeSeconds: int(adapter.UptimeSeconds()),
+					MemoryAvail:   adapter.MaxMemoryBytes(),
+					MemoryUsage:   adapter.MemoryBytes(),
+					HitCount:      adapter.CacheHits(),
+					MissNoData:    adapter.CacheMisses(),
+				}
+			},
+		})
+		telemetryDone = make(chan struct{})
+		go func() { tc.Run(telCtx); close(telemetryDone) }()
 	}
 
 	// Handle signals
@@ -281,6 +325,10 @@ Examples:
 	go func() {
 		<-sigCh
 		slog.Info("Shutting down")
+		if telemetryCancel != nil {
+			telemetryCancel()
+			<-telemetryDone
+		}
 		if metricsServer != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()

--- a/sql/cli.go
+++ b/sql/cli.go
@@ -171,7 +171,7 @@ func Run(args []string) error {
 			},
 		})
 		telemetryDone = make(chan struct{})
-		go func() { tc.Run(telCtx); close(telemetryDone) }()
+		go func() { defer close(telemetryDone); tc.Run(telCtx) }()
 	}
 
 	stopTelemetry := func() {

--- a/sql/cli.go
+++ b/sql/cli.go
@@ -33,7 +33,10 @@ import (
 	"time"
 
 	"github.com/swytchdb/cache/beacon"
+	"github.com/swytchdb/cache/telemetry"
 )
+
+var Version = "dev"
 
 // Run parses CLI arguments and runs the SQL server until terminated by
 // SIGINT/SIGTERM. When a cluster passphrase is supplied the server
@@ -61,6 +64,10 @@ func Run(args []string) error {
 	maxMemoryStr := fs.String("maxmemory", "64mb",
 		"Max effects-engine memory (e.g. 256mb, 4gb)")
 
+	// Telemetry
+	noTelemetry := fs.Bool("no-telemetry", false, "Disable anonymous usage telemetry")
+	inviteMe := fs.String("invite-me", "", "Register as an early adopter with your email (overrides --no-telemetry)")
+
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -68,6 +75,9 @@ func Run(args []string) error {
 	if *clusterPassphrase == "" && *joinAddr != "" {
 		return fmt.Errorf("--join requires --cluster-passphrase")
 	}
+
+	telemetryEnabled := !*noTelemetry || *inviteMe != ""
+	telemetry.PrintBanner(telemetryEnabled, *inviteMe)
 
 	maxMemoryBytes, maxMemoryPct, err := beacon.ParseMemoryLimit(*maxMemoryStr)
 	if err != nil {
@@ -136,13 +146,50 @@ func Run(args []string) error {
 		return errors.Join(err, rt.Stop())
 	}
 
+	// Start telemetry client
+	var telemetryCancel context.CancelFunc
+	var telemetryDone chan struct{}
+	if telemetryEnabled {
+		telCtx, cancel := context.WithCancel(context.Background())
+		telemetryCancel = cancel
+		startTime := time.Now()
+		nodeID := fmt.Sprintf("%x", uint64(rt.Engine.NodeID()))
+		tc := telemetry.New(telemetry.Config{
+			NodeID:       nodeID,
+			Version:      Version,
+			Features:     "sql",
+			AdopterEmail: *inviteMe,
+			StatsFunc: func() telemetry.HeartbeatStats {
+				nodes := 1
+				if rt.PeerManager != nil {
+					nodes = len(rt.PeerManager.PeerIDs()) + 1
+				}
+				return telemetry.HeartbeatStats{
+					Nodes:         nodes,
+					UptimeSeconds: int(time.Since(startTime).Seconds()),
+				}
+			},
+		})
+		telemetryDone = make(chan struct{})
+		go func() { tc.Run(telCtx); close(telemetryDone) }()
+	}
+
+	stopTelemetry := func() {
+		if telemetryCancel != nil {
+			telemetryCancel()
+			<-telemetryDone
+		}
+	}
+
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	select {
 	case sig := <-sigCh:
 		logger.Info("shutdown signal received", "signal", sig.String())
+		stopTelemetry()
 	case err := <-server.Done():
+		stopTelemetry()
 		if err != nil {
 			return errors.Join(
 				fmt.Errorf("server exited: %w", err),

--- a/telemetry/banner.go
+++ b/telemetry/banner.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Swytch Labs BV
+ *
+ * This file is part of Swytch.
+ *
+ * Swytch is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Swytch is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Swytch. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package telemetry
+
+import "fmt"
+
+func PrintBanner(enabled bool, adopterEmail string) {
+	if enabled {
+		fmt.Println("Telemetry: enabled — community dashboard at https://stats.getswytch.com (your telemetry helps everyone). Disable with --no-telemetry.")
+	} else {
+		fmt.Println("Telemetry: disabled. The community dashboard at https://stats.getswytch.com relies on anonymous metrics — consider enabling next time to help.")
+	}
+	if adopterEmail != "" {
+		fmt.Printf("Adopter email registered: %s.\n", adopterEmail)
+	}
+}

--- a/telemetry/banner.go
+++ b/telemetry/banner.go
@@ -28,6 +28,6 @@ func PrintBanner(enabled bool, adopterEmail string) {
 		fmt.Println("Telemetry: disabled. The community dashboard at https://stats.getswytch.com relies on anonymous metrics — consider enabling next time to help.")
 	}
 	if adopterEmail != "" {
-		fmt.Printf("Adopter email registered: %s.\n", adopterEmail)
+		fmt.Println("Early adopter email registered.")
 	}
 }

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Swytch Labs BV
+ *
+ * This file is part of Swytch.
+ *
+ * Swytch is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Swytch is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Swytch. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package telemetry
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+const defaultEndpoint = "https://stats.getswytch.com"
+
+type HeartbeatStats struct {
+	Nodes          int
+	UptimeSeconds  int
+	MemoryAvail    int64
+	MemoryUsage    int64
+	HitCount       uint64
+	MissNoData     uint64
+	MissRemoteData uint64
+}
+
+type Config struct {
+	NodeID       string
+	Version      string
+	Features     string
+	AdopterEmail string
+	StatsFunc    func() HeartbeatStats
+}
+
+type Client struct {
+	nodeID   string
+	version  string
+	goos     string
+	goarch   string
+	features string
+
+	adopterEmail string
+	statsFunc    func() HeartbeatStats
+
+	httpClient        *http.Client
+	endpoint          string
+	heartbeatInterval time.Duration
+}
+
+func New(cfg Config) *Client {
+	return &Client{
+		nodeID:            cfg.NodeID,
+		version:           cfg.Version,
+		goos:              runtime.GOOS,
+		goarch:            runtime.GOARCH,
+		features:          cfg.Features,
+		adopterEmail:      cfg.AdopterEmail,
+		statsFunc:         cfg.StatsFunc,
+		httpClient:        &http.Client{Timeout: 5 * time.Second},
+		endpoint:          defaultEndpoint,
+		heartbeatInterval: 5 * time.Minute,
+	}
+}
+
+func (c *Client) Run(ctx context.Context) {
+	c.sendStartup(ctx)
+	if c.adopterEmail != "" {
+		c.sendAdopter(ctx)
+	}
+
+	ticker := time.NewTicker(c.heartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			finalCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			c.sendHeartbeat(finalCtx)
+			cancel()
+			return
+		case <-ticker.C:
+			c.sendHeartbeat(ctx)
+		}
+	}
+}
+
+func (c *Client) sendStartup(ctx context.Context) {
+	params := url.Values{}
+	params.Set("ev", "startup")
+	params.Set("node_id", c.nodeID)
+	params.Set("ver", c.version)
+	params.Set("os", c.goos)
+	params.Set("arch", c.goarch)
+	if c.features != "" {
+		params.Set("features", c.features)
+	}
+	c.doGet(ctx, params)
+}
+
+func (c *Client) sendHeartbeat(ctx context.Context) {
+	stats := c.statsFunc()
+	params := url.Values{}
+	params.Set("ev", "heartbeat")
+	params.Set("node_id", c.nodeID)
+	params.Set("nodes", strconv.Itoa(stats.Nodes))
+	params.Set("uptime", strconv.Itoa(stats.UptimeSeconds))
+	if stats.MemoryAvail != 0 {
+		params.Set("memory_available", strconv.FormatInt(stats.MemoryAvail, 10))
+	}
+	if stats.MemoryUsage != 0 {
+		params.Set("memory_usage", strconv.FormatInt(stats.MemoryUsage, 10))
+	}
+	if stats.HitCount != 0 {
+		params.Set("hit_count", strconv.FormatUint(stats.HitCount, 10))
+	}
+	if stats.MissNoData != 0 {
+		params.Set("miss_no_data_count", strconv.FormatUint(stats.MissNoData, 10))
+	}
+	if stats.MissRemoteData != 0 {
+		params.Set("miss_remote_data_count", strconv.FormatUint(stats.MissRemoteData, 10))
+	}
+	c.doGet(ctx, params)
+}
+
+func (c *Client) sendAdopter(ctx context.Context) {
+	params := url.Values{}
+	params.Set("ev", "early-adopter")
+	params.Set("node_id", c.nodeID)
+	params.Set("email", c.adopterEmail)
+	c.doGet(ctx, params)
+}
+
+func (c *Client) doGet(ctx context.Context, params url.Values) {
+	u := c.endpoint + "/t/v1/nearcache?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		slog.Debug("telemetry: build request", "error", err)
+		return
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		slog.Debug("telemetry: send", "error", err)
+		return
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+}

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -21,6 +21,7 @@ package telemetry
 
 import (
 	"context"
+	"encoding/base64"
 	"io"
 	"log/slog"
 	"net/http"
@@ -66,6 +67,10 @@ type Client struct {
 }
 
 func New(cfg Config) *Client {
+	sf := cfg.StatsFunc
+	if sf == nil {
+		sf = func() HeartbeatStats { return HeartbeatStats{} }
+	}
 	return &Client{
 		nodeID:            cfg.NodeID,
 		version:           cfg.Version,
@@ -73,7 +78,7 @@ func New(cfg Config) *Client {
 		goarch:            runtime.GOARCH,
 		features:          cfg.Features,
 		adopterEmail:      cfg.AdopterEmail,
-		statsFunc:         cfg.StatsFunc,
+		statsFunc:         sf,
 		httpClient:        &http.Client{Timeout: 5 * time.Second},
 		endpoint:          defaultEndpoint,
 		heartbeatInterval: 5 * time.Minute,
@@ -144,7 +149,7 @@ func (c *Client) sendAdopter(ctx context.Context) {
 	params := url.Values{}
 	params.Set("ev", "early-adopter")
 	params.Set("node_id", c.nodeID)
-	params.Set("email", c.adopterEmail)
+	params.Set("email", base64.StdEncoding.EncodeToString([]byte(c.adopterEmail)))
 	c.doGet(ctx, params)
 }
 
@@ -156,10 +161,11 @@ func (c *Client) doGet(ctx context.Context, params url.Values) {
 		return
 	}
 	resp, err := c.httpClient.Do(req)
+	if resp != nil && resp.Body != nil {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
 	if err != nil {
 		slog.Debug("telemetry: send", "error", err)
-		return
 	}
-	io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
 }

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -21,6 +21,7 @@ package telemetry
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -219,8 +220,9 @@ func TestAdopterEvent(t *testing.T) {
 	if ev.Get("node_id") != "bbb" {
 		t.Errorf("expected node_id=bbb, got %q", ev.Get("node_id"))
 	}
-	if ev.Get("email") != "test@example.com" {
-		t.Errorf("expected email=test@example.com, got %q", ev.Get("email"))
+	wantEmail := base64.StdEncoding.EncodeToString([]byte("test@example.com"))
+	if ev.Get("email") != wantEmail {
+		t.Errorf("expected email=%s, got %q", wantEmail, ev.Get("email"))
 	}
 }
 
@@ -274,8 +276,9 @@ func TestInviteMeOverride(t *testing.T) {
 			hasStartup = true
 		case "early-adopter":
 			hasAdopter = true
-			if r.Get("email") != "early@adopter.com" {
-				t.Errorf("expected email=early@adopter.com, got %q", r.Get("email"))
+			wantEmail := base64.StdEncoding.EncodeToString([]byte("early@adopter.com"))
+			if r.Get("email") != wantEmail {
+				t.Errorf("expected email=%s, got %q", wantEmail, r.Get("email"))
 			}
 		}
 	}
@@ -370,5 +373,47 @@ func TestFinalHeartbeatOnShutdown(t *testing.T) {
 	}
 	if !hasHeartbeat {
 		t.Error("expected a final heartbeat on shutdown")
+	}
+}
+
+func TestNilStatsFuncDoesNotPanic(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:  "hhh",
+		Version: "1.0.0",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); c.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Run did not stop within 100ms of ctx cancel")
+	}
+
+	reqs := rec.get()
+	hasStartup := false
+	hasHeartbeat := false
+	for _, r := range reqs {
+		switch r.Get("ev") {
+		case "startup":
+			hasStartup = true
+		case "heartbeat":
+			hasHeartbeat = true
+		}
+	}
+	if !hasStartup {
+		t.Error("expected startup event even with nil StatsFunc")
+	}
+	if !hasHeartbeat {
+		t.Error("expected final heartbeat even with nil StatsFunc")
 	}
 }

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2026 Swytch Labs BV
+ *
+ * This file is part of Swytch.
+ *
+ * Swytch is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Swytch is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Swytch. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recorder struct {
+	mu       sync.Mutex
+	requests []url.Values
+}
+
+func (r *recorder) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.mu.Lock()
+		r.requests = append(r.requests, req.URL.Query())
+		r.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func (r *recorder) get() []url.Values {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]url.Values, len(r.requests))
+	copy(cp, r.requests)
+	return cp
+}
+
+func newTestClient(ts *httptest.Server, cfg Config) *Client {
+	c := New(cfg)
+	c.endpoint = ts.URL
+	c.heartbeatInterval = 50 * time.Millisecond
+	return c
+}
+
+func dummyStats() HeartbeatStats {
+	return HeartbeatStats{Nodes: 3, UptimeSeconds: 120}
+}
+
+func TestStartupEvent(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:    "abc123",
+		Version:   "1.0.0",
+		Features:  "redis",
+		StatsFunc: dummyStats,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { c.Run(ctx); close(done) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+
+	reqs := rec.get()
+	if len(reqs) == 0 {
+		t.Fatal("expected at least one request")
+	}
+
+	startup := reqs[0]
+	if startup.Get("ev") != "startup" {
+		t.Errorf("expected ev=startup, got %q", startup.Get("ev"))
+	}
+	if startup.Get("node_id") != "abc123" {
+		t.Errorf("expected node_id=abc123, got %q", startup.Get("node_id"))
+	}
+	if startup.Get("ver") != "1.0.0" {
+		t.Errorf("expected ver=1.0.0, got %q", startup.Get("ver"))
+	}
+	if startup.Get("os") != runtime.GOOS {
+		t.Errorf("expected os=%s, got %q", runtime.GOOS, startup.Get("os"))
+	}
+	if startup.Get("arch") != runtime.GOARCH {
+		t.Errorf("expected arch=%s, got %q", runtime.GOARCH, startup.Get("arch"))
+	}
+	if startup.Get("features") != "redis" {
+		t.Errorf("expected features=redis, got %q", startup.Get("features"))
+	}
+}
+
+func TestHeartbeatEvent(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:  "def456",
+		Version: "2.0.0",
+		StatsFunc: func() HeartbeatStats {
+			return HeartbeatStats{
+				Nodes:         5,
+				UptimeSeconds: 300,
+				MemoryAvail:   1024,
+				MemoryUsage:   512,
+				HitCount:      100,
+				MissNoData:    10,
+			}
+		},
+	})
+
+	ctx := context.Background()
+	c.sendHeartbeat(ctx)
+
+	reqs := rec.get()
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+
+	hb := reqs[0]
+	if hb.Get("ev") != "heartbeat" {
+		t.Errorf("expected ev=heartbeat, got %q", hb.Get("ev"))
+	}
+	if hb.Get("node_id") != "def456" {
+		t.Errorf("expected node_id=def456, got %q", hb.Get("node_id"))
+	}
+	if hb.Get("nodes") != "5" {
+		t.Errorf("expected nodes=5, got %q", hb.Get("nodes"))
+	}
+	if hb.Get("uptime") != "300" {
+		t.Errorf("expected uptime=300, got %q", hb.Get("uptime"))
+	}
+	if hb.Get("memory_available") != "1024" {
+		t.Errorf("expected memory_available=1024, got %q", hb.Get("memory_available"))
+	}
+	if hb.Get("memory_usage") != "512" {
+		t.Errorf("expected memory_usage=512, got %q", hb.Get("memory_usage"))
+	}
+	if hb.Get("hit_count") != "100" {
+		t.Errorf("expected hit_count=100, got %q", hb.Get("hit_count"))
+	}
+	if hb.Get("miss_no_data_count") != "10" {
+		t.Errorf("expected miss_no_data_count=10, got %q", hb.Get("miss_no_data_count"))
+	}
+	if hb.Get("miss_remote_data_count") != "" {
+		t.Errorf("expected miss_remote_data_count omitted, got %q", hb.Get("miss_remote_data_count"))
+	}
+}
+
+func TestHeartbeatOmitsZeroOptionals(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:  "aaa",
+		Version: "1.0.0",
+		StatsFunc: func() HeartbeatStats {
+			return HeartbeatStats{Nodes: 1, UptimeSeconds: 60}
+		},
+	})
+
+	c.sendHeartbeat(context.Background())
+
+	reqs := rec.get()
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	hb := reqs[0]
+	for _, key := range []string{"memory_available", "memory_usage", "hit_count", "miss_no_data_count", "miss_remote_data_count"} {
+		if hb.Get(key) != "" {
+			t.Errorf("expected %s omitted, got %q", key, hb.Get(key))
+		}
+	}
+}
+
+func TestAdopterEvent(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:       "bbb",
+		Version:      "1.0.0",
+		AdopterEmail: "test@example.com",
+		StatsFunc:    dummyStats,
+	})
+
+	c.sendAdopter(context.Background())
+
+	reqs := rec.get()
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	ev := reqs[0]
+	if ev.Get("ev") != "early-adopter" {
+		t.Errorf("expected ev=early-adopter, got %q", ev.Get("ev"))
+	}
+	if ev.Get("node_id") != "bbb" {
+		t.Errorf("expected node_id=bbb, got %q", ev.Get("node_id"))
+	}
+	if ev.Get("email") != "test@example.com" {
+		t.Errorf("expected email=test@example.com, got %q", ev.Get("email"))
+	}
+}
+
+func TestNoRequests(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	_ = newTestClient(ts, Config{
+		NodeID:  "ccc",
+		Version: "1.0.0",
+		StatsFunc: func() HeartbeatStats {
+			return HeartbeatStats{Nodes: 1, UptimeSeconds: 0}
+		},
+	})
+
+	time.Sleep(20 * time.Millisecond)
+
+	reqs := rec.get()
+	if len(reqs) != 0 {
+		t.Errorf("expected 0 requests without Run, got %d", len(reqs))
+	}
+}
+
+func TestInviteMeOverride(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:       "ddd",
+		Version:      "1.0.0",
+		AdopterEmail: "early@adopter.com",
+		StatsFunc:    dummyStats,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { c.Run(ctx); close(done) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+
+	reqs := rec.get()
+	hasStartup := false
+	hasAdopter := false
+	for _, r := range reqs {
+		switch r.Get("ev") {
+		case "startup":
+			hasStartup = true
+		case "early-adopter":
+			hasAdopter = true
+			if r.Get("email") != "early@adopter.com" {
+				t.Errorf("expected email=early@adopter.com, got %q", r.Get("email"))
+			}
+		}
+	}
+	if !hasStartup {
+		t.Error("expected startup event")
+	}
+	if !hasAdopter {
+		t.Error("expected early-adopter event")
+	}
+}
+
+func TestCancelStopsTicker(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:  "eee",
+		Version: "1.0.0",
+		StatsFunc: func() HeartbeatStats {
+			return HeartbeatStats{Nodes: 1, UptimeSeconds: 1}
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { c.Run(ctx); close(done) }()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Run did not stop within 100ms of ctx cancel")
+	}
+}
+
+func TestHTTPErrorsSwallowed(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:  "fff",
+		Version: "1.0.0",
+		StatsFunc: func() HeartbeatStats {
+			return HeartbeatStats{Nodes: 1, UptimeSeconds: 1}
+		},
+	})
+
+	c.sendStartup(context.Background())
+	c.sendHeartbeat(context.Background())
+	c.sendAdopter(context.Background())
+}
+
+func TestFinalHeartbeatOnShutdown(t *testing.T) {
+	rec := &recorder{}
+	ts := httptest.NewServer(rec.handler())
+	defer ts.Close()
+
+	c := newTestClient(ts, Config{
+		NodeID:  "ggg",
+		Version: "1.0.0",
+		StatsFunc: func() HeartbeatStats {
+			return HeartbeatStats{Nodes: 2, UptimeSeconds: 42}
+		},
+	})
+	c.heartbeatInterval = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { c.Run(ctx); close(done) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+
+	reqs := rec.get()
+	hasHeartbeat := false
+	for _, r := range reqs {
+		if r.Get("ev") == "heartbeat" {
+			hasHeartbeat = true
+			if r.Get("nodes") != "2" {
+				t.Errorf("expected nodes=2, got %q", r.Get("nodes"))
+			}
+			if r.Get("uptime") != "42" {
+				t.Errorf("expected uptime=42, got %q", r.Get("uptime"))
+			}
+		}
+	}
+	if !hasHeartbeat {
+		t.Error("expected a final heartbeat on shutdown")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags to opt out of anonymous telemetry and to register an early-adopter email.
  * Startup banner showing telemetry status and early-adopter registration.
  * Periodic anonymous telemetry heartbeat when enabled; telemetry runs alongside existing metrics.

* **Behavioral**
  * Shutdown now waits for telemetry to finish before stopping services for cleaner exit.

* **Tests**
  * Comprehensive telemetry client tests added to validate startup, heartbeat, adopter, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->