### PR TITLE
Fix bootstrapping and telemetry

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -100,6 +100,23 @@ func (b *Beacon) Start(ctx context.Context) error {
 		}
 	}
 
+	if b.cfg.JoinAddr != "" && b.expectedPeers > 0 {
+		// Phase 1.5: Wait for at least one peer to become alive+symmetric
+		// via heartbeat exchange. With immediate heartbeats sent on
+		// connection (PeerManager wiring), this completes in <100ms.
+		// Required so registerSelf's SafeMode replication has valid targets.
+		symCtx, symCancel := context.WithTimeout(b.ctx, 10*time.Second)
+		if err := b.waitForSymmetricPeers(symCtx); err != nil {
+			slog.Warn("beacon: no symmetric peers available, continuing anyway", "error", err)
+		}
+		symCancel()
+
+		// Phase 1.75: Subscribe to the membership key before registering
+		// self. NACKs from peers carry their existing membership tips so
+		// the local engine has peer data before registerSelf runs.
+		b.primeSubscription()
+	}
+
 	// Phase 2: Register self in membership. Local emit — fast.
 	if err := b.registerSelf(); err != nil {
 		return err
@@ -148,6 +165,36 @@ func (b *Beacon) Members() []Member {
 	return out
 }
 
+
+// waitForSymmetricPeers blocks until at least one peer is alive+symmetric
+// in the health table, or ctx is cancelled.
+func (b *Beacon) waitForSymmetricPeers(ctx context.Context) error {
+	ht := b.pm.HealthTable()
+	if ht == nil {
+		return nil
+	}
+	for {
+		if len(ht.AlivePeerIDs()) > 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// primeSubscription triggers an early subscription to the membership key
+// by calling GetSnapshot. NACKs from peers carry their existing membership
+// tips into the local engine. Errors are non-fatal since the subscription
+// will be retried during waitForMembershipConverged.
+func (b *Beacon) primeSubscription() {
+	_, _, _, err := b.engine.GetSnapshot(MembershipKey)
+	if err != nil {
+		slog.Debug("beacon: prime subscription incomplete (will retry)", "error", err)
+	}
+}
 
 // registerSelf writes this node's INSERT_OP + type tag + initial TTL.
 func (b *Beacon) registerSelf() error {

--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -106,15 +106,16 @@ func (b *Beacon) Start(ctx context.Context) error {
 		// connection (PeerManager wiring), this completes in <100ms.
 		// Required so registerSelf's SafeMode replication has valid targets.
 		symCtx, symCancel := context.WithTimeout(b.ctx, 10*time.Second)
-		if err := b.waitForSymmetricPeers(symCtx); err != nil {
-			slog.Warn("beacon: no symmetric peers available, continuing anyway", "error", err)
-		}
+		err := b.waitForSymmetricPeers(symCtx)
 		symCancel()
-
-		// Phase 1.75: Subscribe to the membership key before registering
-		// self. NACKs from peers carry their existing membership tips so
-		// the local engine has peer data before registerSelf runs.
-		b.primeSubscription()
+		if err != nil {
+			slog.Warn("beacon: no symmetric peers available, skipping prime subscription", "error", err)
+		} else {
+			// Phase 1.75: Subscribe to the membership key before registering
+			// self. NACKs from peers carry their existing membership tips so
+			// the local engine has peer data before registerSelf runs.
+			b.primeSubscription()
+		}
 	}
 
 	// Phase 2: Register self in membership. Local emit — fast.

--- a/cluster/heartbeat.go
+++ b/cluster/heartbeat.go
@@ -104,6 +104,20 @@ func (hm *HeartbeatManager) Start(sendFunc func(peerID NodeId, data []byte) erro
 	go hm.livenessLoop()
 }
 
+// SendHeartbeatTo sends a single heartbeat to a specific peer immediately,
+// bypassing the ticker. Used to accelerate symmetry establishment on new
+// connections.
+func (hm *HeartbeatManager) SendHeartbeatTo(peerID NodeId) {
+	if hm.sendFunc == nil {
+		return
+	}
+	timestamp := uint64(time.Now().UnixNano())
+	packet := MarshalHeartbeat(hm.nodeID, timestamp)
+	if err := hm.sendFunc(peerID, packet); err != nil {
+		slog.Debug("immediate heartbeat send failed", "peer", peerID, "error", err)
+	}
+}
+
 // Stop stops the heartbeat manager.
 func (hm *HeartbeatManager) Stop() {
 	close(hm.cancel)

--- a/cluster/peer_manager.go
+++ b/cluster/peer_manager.go
@@ -192,7 +192,7 @@ func (pm *PeerManager) Start(ctx context.Context) error {
 			},
 			func(peerID NodeId, conn *quic.Conn) {
 				pm.registerInboundConn(peerID, conn)
-				if pm.heartbeat != nil {
+				if peerID != pm.selfID && pm.heartbeat != nil {
 					pm.heartbeat.SendHeartbeatTo(peerID)
 				}
 			},

--- a/cluster/peer_manager.go
+++ b/cluster/peer_manager.go
@@ -190,7 +190,12 @@ func (pm *PeerManager) Start(ctx context.Context) error {
 				}
 				return pm.inboundConnFor(peerID)
 			},
-			pm.registerInboundConn,
+			func(peerID NodeId, conn *quic.Conn) {
+				pm.registerInboundConn(peerID, conn)
+				if pm.heartbeat != nil {
+					pm.heartbeat.SendHeartbeatTo(peerID)
+				}
+			},
 		)
 
 		// Start heartbeat manager
@@ -212,7 +217,13 @@ func (pm *PeerManager) Start(ctx context.Context) error {
 	// Connect to all peers
 	pm.mu.Lock()
 	for _, peer := range pm.config.Peers() {
-		pc := newPeerConn(peer.ID, peer.Address, peer.Region, selfRegion, pm.handler, pm.clientTLS, pm.acceptOutboundStreams)
+		peerID := peer.ID
+		pc := newPeerConn(peer.ID, peer.Address, peer.Region, selfRegion, pm.handler, pm.clientTLS, func(conn *quic.Conn) {
+			pm.acceptOutboundStreams(conn)
+			if pm.heartbeat != nil {
+				pm.heartbeat.SendHeartbeatTo(peerID)
+			}
+		})
 		pm.peers[peer.ID] = pc
 		pc.Start(pm.ctx)
 
@@ -547,7 +558,13 @@ func (pm *PeerManager) UpdateTopology(newCfg *ClusterConfig) {
 	// Connect new peers
 	for _, added := range diff.Added {
 		slog.Info("connecting to new peer", "peer", added.ID, "address", added.Address, "region", added.Region)
-		pc := newPeerConn(added.ID, added.Address, added.Region, selfRegion, pm.handler, pm.clientTLS, pm.acceptOutboundStreams)
+		peerID := added.ID
+		pc := newPeerConn(added.ID, added.Address, added.Region, selfRegion, pm.handler, pm.clientTLS, func(conn *quic.Conn) {
+			pm.acceptOutboundStreams(conn)
+			if pm.heartbeat != nil {
+				pm.heartbeat.SendHeartbeatTo(peerID)
+			}
+		})
 		pm.peers[added.ID] = pc
 		pc.Start(pm.ctx)
 		pm.registerPeer(added)
@@ -561,7 +578,13 @@ func (pm *PeerManager) UpdateTopology(newCfg *ClusterConfig) {
 			delete(pm.peers, changed.ID)
 		}
 		pm.unregisterPeer(changed.ID)
-		pc := newPeerConn(changed.ID, changed.Address, changed.Region, selfRegion, pm.handler, pm.clientTLS, pm.acceptOutboundStreams)
+		peerID := changed.ID
+		pc := newPeerConn(changed.ID, changed.Address, changed.Region, selfRegion, pm.handler, pm.clientTLS, func(conn *quic.Conn) {
+			pm.acceptOutboundStreams(conn)
+			if pm.heartbeat != nil {
+				pm.heartbeat.SendHeartbeatTo(peerID)
+			}
+		})
 		pm.peers[changed.ID] = pc
 		pc.Start(pm.ctx)
 		pm.registerPeer(changed)

--- a/effects/effect.go
+++ b/effects/effect.go
@@ -226,7 +226,11 @@ func NewEngine(cfg EngineConfig) *Engine {
 		pendingTxTips:      xsync.NewMap[keytrie.EffectRef, []Tip](),
 		txAbortCounts:      xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps:  xsync.NewMap[string, *bootstrapCollector](),
-		effectCache:        clox.NewCloxCache[keytrie.EffectRef, *pb.Effect](clox.ConfigFromMemorySize(effectCacheSize(cfg.MemoryLimit))),
+		effectCache: clox.NewCloxCache[keytrie.EffectRef, *pb.Effect](func() clox.Config {
+			c := clox.ConfigFromMemorySize(effectCacheSize(cfg.MemoryLimit))
+			c.CollectStats = true
+			return c
+		}()),
 		voidedBinds:        xsync.NewMap[string, struct{}](),
 	}
 	e.cache = cache

--- a/redis/cmd.go
+++ b/redis/cmd.go
@@ -304,13 +304,19 @@ Examples:
 				if activeRuntime != nil && activeRuntime.PeerManager != nil {
 					nodes = len(activeRuntime.PeerManager.PeerIDs()) + 1
 				}
+				ec := activeRuntime.Engine.EffectCache()
+				hits, misses, evictions := ec.Stats()
 				return telemetry.HeartbeatStats{
 					Nodes:         nodes,
 					UptimeSeconds: int(adapter.UptimeSeconds()),
-					MemoryAvail:   adapter.MaxMemoryBytes(),
-					MemoryUsage:   adapter.MemoryBytes(),
-					HitCount:      adapter.CacheHits(),
-					MissNoData:    adapter.CacheMisses(),
+					MemoryAvail:   ec.MemoryLimit(),
+					MemoryUsage:   ec.Bytes(),
+					HitCount:      hits,
+					MissCount:     misses,
+					Evictions:     evictions,
+					EntryCount:    ec.EntryCount(),
+					Capacity:      ec.Capacity(),
+					AverageK:      ec.AverageK(),
 				}
 			},
 		})

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -39,8 +39,11 @@ type HeartbeatStats struct {
 	MemoryAvail    int64
 	MemoryUsage    int64
 	HitCount       uint64
-	MissNoData     uint64
-	MissRemoteData uint64
+	MissCount      uint64
+	Evictions      uint64
+	EntryCount     int
+	Capacity       int
+	AverageK       float64
 }
 
 type Config struct {
@@ -136,11 +139,20 @@ func (c *Client) sendHeartbeat(ctx context.Context) {
 	if stats.HitCount != 0 {
 		params.Set("hit_count", strconv.FormatUint(stats.HitCount, 10))
 	}
-	if stats.MissNoData != 0 {
-		params.Set("miss_no_data_count", strconv.FormatUint(stats.MissNoData, 10))
+	if stats.MissCount != 0 {
+		params.Set("miss_count", strconv.FormatUint(stats.MissCount, 10))
 	}
-	if stats.MissRemoteData != 0 {
-		params.Set("miss_remote_data_count", strconv.FormatUint(stats.MissRemoteData, 10))
+	if stats.Evictions != 0 {
+		params.Set("evictions", strconv.FormatUint(stats.Evictions, 10))
+	}
+	if stats.EntryCount != 0 {
+		params.Set("entry_count", strconv.Itoa(stats.EntryCount))
+	}
+	if stats.Capacity != 0 {
+		params.Set("capacity", strconv.Itoa(stats.Capacity))
+	}
+	if stats.AverageK != 0 {
+		params.Set("average_k", strconv.FormatFloat(stats.AverageK, 'f', 2, 64))
 	}
 	c.doGet(ctx, params)
 }

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -125,7 +125,11 @@ func TestHeartbeatEvent(t *testing.T) {
 				MemoryAvail:   1024,
 				MemoryUsage:   512,
 				HitCount:      100,
-				MissNoData:    10,
+				MissCount:     10,
+				Evictions:     3,
+				EntryCount:    50,
+				Capacity:      200,
+				AverageK:      1.5,
 			}
 		},
 	})
@@ -160,11 +164,20 @@ func TestHeartbeatEvent(t *testing.T) {
 	if hb.Get("hit_count") != "100" {
 		t.Errorf("expected hit_count=100, got %q", hb.Get("hit_count"))
 	}
-	if hb.Get("miss_no_data_count") != "10" {
-		t.Errorf("expected miss_no_data_count=10, got %q", hb.Get("miss_no_data_count"))
+	if hb.Get("miss_count") != "10" {
+		t.Errorf("expected miss_count=10, got %q", hb.Get("miss_count"))
 	}
-	if hb.Get("miss_remote_data_count") != "" {
-		t.Errorf("expected miss_remote_data_count omitted, got %q", hb.Get("miss_remote_data_count"))
+	if hb.Get("evictions") != "3" {
+		t.Errorf("expected evictions=3, got %q", hb.Get("evictions"))
+	}
+	if hb.Get("entry_count") != "50" {
+		t.Errorf("expected entry_count=50, got %q", hb.Get("entry_count"))
+	}
+	if hb.Get("capacity") != "200" {
+		t.Errorf("expected capacity=200, got %q", hb.Get("capacity"))
+	}
+	if hb.Get("average_k") != "1.50" {
+		t.Errorf("expected average_k=1.50, got %q", hb.Get("average_k"))
 	}
 }
 
@@ -188,7 +201,7 @@ func TestHeartbeatOmitsZeroOptionals(t *testing.T) {
 		t.Fatalf("expected 1 request, got %d", len(reqs))
 	}
 	hb := reqs[0]
-	for _, key := range []string{"memory_available", "memory_usage", "hit_count", "miss_no_data_count", "miss_remote_data_count"} {
+	for _, key := range []string{"memory_available", "memory_usage", "hit_count", "miss_count", "evictions", "entry_count", "capacity", "average_k"} {
 		if hb.Get(key) != "" {
 			t.Errorf("expected %s omitted, got %q", key, hb.Get(key))
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Immediate heartbeat send to a specific peer, used to speed up coordination for new connections.

* **Improvements**
  * Peer join now waits for symmetric peers and primes membership before registration when DNS clustering is used.
  * Telemetry expanded to report detailed cache metrics (evictions, entry count, capacity, average key size); runtime cache now collects stats.

* **Tests**
  * Telemetry tests updated to match the new heartbeat metric shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->