### PR TITLE
add telemetry to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY keytrie/ ./keytrie/
 COPY metrics/ ./metrics/
 COPY redis/ ./redis/
 COPY sql/ ./sql/
+COPY telemetry/ ./telemetry/
 COPY tracing/ ./tracing/
 COPY *.go .
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the telemetry directory was not included in Docker builds, ensuring all necessary components are properly available during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->