### PR TITLE
use a cluster id

### DIFF
--- a/cluster/metrics_test.go
+++ b/cluster/metrics_test.go
@@ -99,4 +99,3 @@ func TestRecordPeerReconnect(t *testing.T) {
 		t.Fatal("expected reconnects counter >= 1")
 	}
 }
-

--- a/redis/cmd.go
+++ b/redis/cmd.go
@@ -37,6 +37,7 @@ import (
 	"github.com/swytchdb/cache/redis/shared"
 	"github.com/swytchdb/cache/telemetry"
 	"github.com/swytchdb/cache/tracing"
+	"github.com/zeebo/xxh3"
 )
 
 // Version is set at build time
@@ -294,8 +295,13 @@ Examples:
 		telCtx, cancel := context.WithCancel(context.Background())
 		telemetryCancel = cancel
 		nodeID := fmt.Sprintf("%x", uint64(activeRuntime.Engine.NodeID()))
+		var clusterID string
+		if effectsCfg.JoinAddr != "" {
+			clusterID = fmt.Sprintf("%x", xxh3.HashString(effectsCfg.JoinAddr))
+		}
 		tc := telemetry.New(telemetry.Config{
 			NodeID:       nodeID,
+			ClusterID:    clusterID,
 			Version:      Version,
 			Features:     "redis",
 			AdopterEmail: *inviteMe,

--- a/sql/cli.go
+++ b/sql/cli.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/swytchdb/cache/beacon"
 	"github.com/swytchdb/cache/telemetry"
+	"github.com/zeebo/xxh3"
 )
 
 var Version = "dev"
@@ -154,8 +155,13 @@ func Run(args []string) error {
 		telemetryCancel = cancel
 		startTime := time.Now()
 		nodeID := fmt.Sprintf("%x", uint64(rt.Engine.NodeID()))
+		var clusterID string
+		if *joinAddr != "" {
+			clusterID = fmt.Sprintf("%x", xxh3.HashString(*joinAddr))
+		}
 		tc := telemetry.New(telemetry.Config{
 			NodeID:       nodeID,
+			ClusterID:    clusterID,
 			Version:      Version,
 			Features:     "sql",
 			AdopterEmail: *inviteMe,

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -48,6 +48,7 @@ type HeartbeatStats struct {
 
 type Config struct {
 	NodeID       string
+	ClusterID    string
 	Version      string
 	Features     string
 	AdopterEmail string
@@ -55,11 +56,12 @@ type Config struct {
 }
 
 type Client struct {
-	nodeID   string
-	version  string
-	goos     string
-	goarch   string
-	features string
+	nodeID    string
+	clusterID string
+	version   string
+	goos      string
+	goarch    string
+	features  string
 
 	adopterEmail string
 	statsFunc    func() HeartbeatStats
@@ -76,6 +78,7 @@ func New(cfg Config) *Client {
 	}
 	return &Client{
 		nodeID:            cfg.NodeID,
+		clusterID:         cfg.ClusterID,
 		version:           cfg.Version,
 		goos:              runtime.GOOS,
 		goarch:            runtime.GOARCH,
@@ -114,6 +117,9 @@ func (c *Client) sendStartup(ctx context.Context) {
 	params := url.Values{}
 	params.Set("ev", "startup")
 	params.Set("node_id", c.nodeID)
+	if c.clusterID != "" {
+		params.Set("cluster_id", c.clusterID)
+	}
 	params.Set("ver", c.version)
 	params.Set("os", c.goos)
 	params.Set("arch", c.goarch)
@@ -128,6 +134,9 @@ func (c *Client) sendHeartbeat(ctx context.Context) {
 	params := url.Values{}
 	params.Set("ev", "heartbeat")
 	params.Set("node_id", c.nodeID)
+	if c.clusterID != "" {
+		params.Set("cluster_id", c.clusterID)
+	}
 	params.Set("nodes", strconv.Itoa(stats.Nodes))
 	params.Set("uptime", strconv.Itoa(stats.UptimeSeconds))
 	if stats.MemoryAvail != 0 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced telemetry infrastructure to capture and report cluster identifiers, enabling improved monitoring and analytics for distributed deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->