### PR TITLE
fix: clear `watchedKeys` in `Context.Abort()` on session disconnect

### DIFF
--- a/effects/context.go
+++ b/effects/context.go
@@ -414,6 +414,7 @@ func (c *Context) CheckWatches() bool {
 // written to the log remain durable but invisible (index not updated).
 func (c *Context) Abort() {
 	clear(c.keys)
+	clear(c.watchedKeys)
 	c.inTx = false
 	c.txnID = ""
 	c.txSnapshot = nil

--- a/effects/emit_test.go
+++ b/effects/emit_test.go
@@ -425,6 +425,73 @@ func TestAbort(t *testing.T) {
 	}
 }
 
+func TestAbortClearsWatchedKeys(t *testing.T) {
+	e := newTestEngine(nil)
+
+	ctx := e.NewContext()
+	ctx.Watch("k1")
+	ctx.Watch("k2")
+
+	if len(ctx.watchedKeys) != 2 {
+		t.Fatalf("expected 2 watchedKeys before Abort, got %d", len(ctx.watchedKeys))
+	}
+
+	ctx.BeginTx()
+	ctx.Abort()
+
+	if len(ctx.watchedKeys) != 0 {
+		t.Fatalf("expected 0 watchedKeys after Abort, got %d", len(ctx.watchedKeys))
+	}
+}
+
+func TestAbortClearsWatchedKeysWithoutTx(t *testing.T) {
+	e := newTestEngine(nil)
+
+	ctx := e.NewContext()
+	ctx.Watch("k")
+
+	if len(ctx.watchedKeys) != 1 {
+		t.Fatalf("expected 1 watchedKey before Abort, got %d", len(ctx.watchedKeys))
+	}
+
+	// Abort without BeginTx — still must clear watchedKeys
+	ctx.Abort()
+
+	if len(ctx.watchedKeys) != 0 {
+		t.Fatalf("expected 0 watchedKeys after Abort, got %d", len(ctx.watchedKeys))
+	}
+}
+
+func TestAbortAllowsCleanReuse(t *testing.T) {
+	e := newTestEngine(nil)
+
+	ctx := e.NewContext()
+	ctx.Watch("k")
+	ctx.BeginTx()
+	if err := ctx.Emit(dataEffect("k")); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx.Abort()
+
+	// All state should be reset: keys, watchedKeys, inTx, txnID, txSnapshot
+	if len(ctx.keys) != 0 {
+		t.Fatal("keys should be empty after Abort")
+	}
+	if len(ctx.watchedKeys) != 0 {
+		t.Fatal("watchedKeys should be empty after Abort")
+	}
+	if ctx.inTx {
+		t.Fatal("inTx should be false after Abort")
+	}
+	if ctx.txnID != "" {
+		t.Fatal("txnID should be empty after Abort")
+	}
+	if ctx.txSnapshot != nil {
+		t.Fatal("txSnapshot should be nil after Abort")
+	}
+}
+
 func TestCASRetry(t *testing.T) {
 	e := newTestEngine(nil)
 


### PR DESCRIPTION
### What

Add `clear(c.watchedKeys)` to `Context.Abort()` so that all transactional state — including WATCH registrations — is fully reset when a transaction is aborted.

### Why

`Abort()` resets `keys`, `inTx`, `txnID`, and `txSnapshot`, but leaves `watchedKeys` populated. When `closeSession()` calls `Abort()` on a mid-transaction disconnect, stale WATCH state survives in the `Context`. The Redis layer is unaffected because it always calls `ClearWatches()` explicitly, but the SQL session teardown path relies solely on `Abort()`.

While `Context` is not reused today, the leftover state violates `Abort()`'s contract of producing a clean slate and is a latent bug if `Context` reuse is ever introduced (e.g., connection pooling).

Fix #27 

### Changes

| File | Change |
|------|--------|
| `effects/context.go` | Add `clear(c.watchedKeys)` to `Abort()` |
| `effects/emit_test.go` | Add 3 test cases covering the fix |

### Tests Added

- **`TestAbortClearsWatchedKeys`** — `Watch` two keys, `BeginTx`, `Abort`, assert `watchedKeys` is empty.
- **`TestAbortClearsWatchedKeysWithoutTx`** — `Watch` a key, `Abort` without `BeginTx`, assert `watchedKeys` is empty.
- **`TestAbortAllowsCleanReuse`** — `Watch` + `BeginTx` + `Emit` + `Abort`, assert every field (`keys`, `watchedKeys`, `inTx`, `txnID`, `txSnapshot`) is fully reset.

### Verification

Full `./effects/` test suite passes with no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction context cleanup to properly clear all optimistic-locking state when aborting transactions.

* **Tests**
  * Added test coverage for transaction abort behavior, including cleanup scenarios with and without active transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->