### PR TITLE
Fix: Replace unbounded `voidedBinds` xsync.Map with capacity-bounded CloxCache

### DIFF
--- a/effects/context.go
+++ b/effects/context.go
@@ -907,20 +907,13 @@ func (c *Context) flushTx() error {
 	}
 
 	// Evaluate fork-choice against existing binds on all keys.
-	c.engine.evaluateBindForkChoice(bind, bindOffset, bindEff.ForkChoiceHash, c.txnID)
-
-	// If a concurrent bind that was emitted between our
-	// checkCompetingBinds pre-flight and our bind's indexing has
-	// won fork-choice over us, we're in voidedBinds now — abort
-	// instead of falsely reporting a commit. Without this check,
-	// two truly-concurrent commits (same ConsumedTips, races past
-	// checkCompetingBinds) would both commit locally while only one
-	// is actually valid per the deterministic fork-choice rule.
-	if _, voided := c.engine.voidedBinds.Load(c.txnID); voided {
+	// Returns true if our bind lost — abort immediately without
+	// re-reading voidedBinds (the cache write is still done for
+	// cross-transaction visibility in reconstruct/checkCompetingBinds).
+	if c.engine.evaluateBindForkChoice(bind, bindOffset, bindEff.ForkChoiceHash, c.txnID) {
 		slog.Debug("flushTx: voided by concurrent bind, aborting",
 			"bind_offset", bindOffset, "txn", c.txnID)
-		for key, ck := range c.keys {
-			_ = key
+		for _, ck := range c.keys {
 			c.engine.pendingTxTips.Delete(ck.lastOffset)
 		}
 		c.reset()

--- a/effects/effect.go
+++ b/effects/effect.go
@@ -103,7 +103,10 @@ type Engine struct {
 	// Voided binds — txnIDs whose binds lost fork-choice or were
 	// SSI-invalidated. Checked by filterTentativeEffects to skip
 	// these binds without per-read DAG walks.
-	voidedBinds *xsync.Map[string, struct{}]
+	// Backed by a low-capacity CloxCache to bound memory; eviction
+	// is safe because reconstruct's wonTips map independently
+	// resolves competing binds.
+	voidedBinds *clox.CloxCache[string, struct{}]
 
 	// Anti-entropy
 	antiEntropyStop chan struct{}
@@ -231,7 +234,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 			c.CollectStats = true
 			return c
 		}()),
-		voidedBinds: xsync.NewMap[string, struct{}](),
+		voidedBinds: clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(8192)),
 	}
 	e.effectCache.SetSizeFunc(func(_ keytrie.EffectRef, v *pb.Effect) int64 {
 		return 16 + int64(proto.Size(v)) // 16 = sizeof(EffectRef=[2]uint64)
@@ -742,7 +745,7 @@ func (e *Engine) checkCompetingBinds(bind *pb.TransactionalBindEffect, txnID str
 				continue
 			}
 			// Skip voided binds (already lost fork-choice)
-			if _, voided := e.voidedBinds.Load(eff.TxnId); voided {
+			if _, voided := e.voidedBinds.Get(eff.TxnId, 0); voided {
 				continue
 			}
 			// Check if they share a consumed tip on any overlapping key.
@@ -791,11 +794,12 @@ func (e *Engine) checkCompetingBinds(bind *pb.TransactionalBindEffect, txnID str
 }
 
 // evaluateBindForkChoice checks a newly arrived bind against all existing
-// binds on its keys. Losers are added to voidedBinds. Also checks for
-// concurrent non-transactional data effects (SSI invalidation).
+// binds on its keys. Losers are added to voidedBinds for cross-transaction
+// visibility. Also checks for concurrent non-transactional data effects
+// (SSI invalidation). Returns true if txnID itself was voided.
 // Called at bind arrival time (HandleRemote or flushTx) so the check
 // happens once, not on every read.
-func (e *Engine) evaluateBindForkChoice(bind *pb.TransactionalBindEffect, bindOffset Tip, bindHash []byte, txnID string) {
+func (e *Engine) evaluateBindForkChoice(bind *pb.TransactionalBindEffect, bindOffset Tip, bindHash []byte, txnID string) bool {
 	newEntry := &forkChoiceBindEntry{
 		offset: bindOffset,
 		hash:   bindHash,
@@ -831,7 +835,7 @@ func (e *Engine) evaluateBindForkChoice(bind *pb.TransactionalBindEffect, bindOf
 					continue // same transaction
 				}
 				// Already voided? skip
-				if _, voided := e.voidedBinds.Load(eff.TxnId); voided {
+				if _, voided := e.voidedBinds.Get(eff.TxnId, 0); voided {
 					continue
 				}
 
@@ -866,14 +870,14 @@ func (e *Engine) evaluateBindForkChoice(bind *pb.TransactionalBindEffect, bindOf
 						slog.Debug("evaluateBindForkChoice: voiding loser",
 							"winner_txn", txnID, "loser_txn", eff.TxnId,
 							"key", k)
-						e.voidedBinds.Store(eff.TxnId, struct{}{})
+						e.voidedBinds.Put(eff.TxnId, struct{}{})
 					} else {
 						// They win, we lose
 						slog.Debug("evaluateBindForkChoice: voiding loser",
 							"winner_txn", eff.TxnId, "loser_txn", txnID,
 							"key", k)
-						e.voidedBinds.Store(txnID, struct{}{})
-						return // we're voided, no need to check more keys
+						e.voidedBinds.Put(txnID, struct{}{})
+						return true
 					}
 				}
 			}
@@ -914,13 +918,14 @@ func (e *Engine) evaluateBindForkChoice(bind *pb.TransactionalBindEffect, bindOf
 						slog.Debug("evaluateBindForkChoice: SSI invalidation",
 							"txn", txnID, "key", k,
 							"concurrent_offset", tipOff)
-						e.voidedBinds.Store(txnID, struct{}{})
-						return
+						e.voidedBinds.Put(txnID, struct{}{})
+						return true
 					}
 				}
 			}
 		}
 	}
+	return false
 }
 
 // HandleNack processes a NACK from a remote peer.
@@ -1027,6 +1032,9 @@ func (e *Engine) Close() error {
 	if e.antiEntropyStop != nil {
 		close(e.antiEntropyStop)
 		e.antiEntropyWg.Wait()
+	}
+	if e.voidedBinds != nil {
+		e.voidedBinds.Close()
 	}
 	return nil
 }

--- a/effects/emit_test.go
+++ b/effects/emit_test.go
@@ -121,7 +121,7 @@ func newTestEngine(bc Broadcaster) *Engine {
 		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
 		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
-		voidedBinds:       xsync.NewMap[string, struct{}](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(256)),
 		effectCache:       clox.NewCloxCache[Tip, *pb.Effect](clox.ConfigFromMemorySize(1024 * 1024)),
 	}
 	e.safety.Store(&safetyMap{defaultMode: UnsafeMode})
@@ -647,7 +647,7 @@ func newTxnTestEngine(bc Broadcaster) *Engine {
 		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
 		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
-		voidedBinds:       xsync.NewMap[string, struct{}](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(256)),
 		effectCache:       clox.NewCloxCache[Tip, *pb.Effect](clox.ConfigFromMemorySize(1024 * 1024)),
 	}
 	e.safety.Store(&safetyMap{defaultMode: UnsafeMode})
@@ -1550,5 +1550,93 @@ func TestFlushTx_ConsumesTips_LinearChain(t *testing.T) {
 		if cached.GetTxnBind() == nil {
 			t.Fatalf("iteration %d: tip at offset %d is not a BIND", i, bindOffset)
 		}
+	}
+}
+
+// TestVoidedBinds_BoundedMemory verifies that the voidedBinds cache does not
+// grow without bound. It stores far more entries than the cache capacity and
+// asserts that the entry count stays bounded. This is the regression test
+// for the xsync.Map memory leak where voided txnIDs accumulated forever.
+func TestVoidedBinds_BoundedMemory(t *testing.T) {
+	const capacity = 8192
+	vb := clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(capacity))
+	defer vb.Close()
+
+	// Insert 4x the capacity — with the old xsync.Map this would have
+	// grown to 4*capacity entries; with CloxCache it stays bounded.
+	const insertCount = capacity * 4
+	for i := range insertCount {
+		vb.Put(fmt.Sprintf("txn:%d", i), struct{}{})
+	}
+
+	count := vb.EntryCount()
+	if count > capacity {
+		t.Fatalf("voidedBinds should be bounded at ~%d entries, got %d", capacity, count)
+	}
+	t.Logf("after %d inserts: %d entries (capacity %d)", insertCount, count, capacity)
+}
+
+// TestVoidedBinds_ReadYourWrites verifies that a txnID stored in the
+// voidedBinds cache is immediately visible to a subsequent lookup on
+// the same goroutine (read-your-writes guarantee within capacity).
+// Uses a large capacity with few inserts to stay well within bounds.
+func TestVoidedBinds_ReadYourWrites(t *testing.T) {
+	const capacity = 8192
+	vb := clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(capacity))
+	defer vb.Close()
+
+	// Insert only 100 entries — well within capacity, so no evictions.
+	for i := range 100 {
+		txnID := fmt.Sprintf("txn:%d", i)
+		vb.Put(txnID, struct{}{})
+		if _, ok := vb.Get(txnID, 0); !ok {
+			t.Fatalf("read-your-writes failed: txnID %q not found immediately after Put", txnID)
+		}
+	}
+}
+
+// TestVoidedBinds_EngineIntegration verifies that the Engine's voidedBinds
+// field is properly bounded by inserting entries and checking that the
+// cache does not grow unbounded.
+func TestVoidedBinds_EngineIntegration(t *testing.T) {
+	// Use production-sized capacity for realistic behavior
+	e := &Engine{
+		index:             keytrie.New(),
+		nodeID:            42,
+		clock:             crdt.NewHLC(),
+		subscriptions:     xsync.NewMap[string, *subscriptionState](),
+		pendingTxns:       xsync.NewMap[Tip, *pendingTxn](),
+		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
+		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
+		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(8192)),
+		effectCache:       clox.NewCloxCache[Tip, *pb.Effect](clox.ConfigFromMemorySize(1024 * 1024)),
+	}
+	e.safety.Store(&safetyMap{defaultMode: UnsafeMode})
+	defer e.voidedBinds.Close()
+	defer e.effectCache.Close()
+
+	cap := e.voidedBinds.Capacity()
+
+	// Insert 3x the capacity to force evictions — with the old
+	// xsync.Map this would have grown to 3*cap; now it's bounded.
+	insertCount := cap * 3
+	for i := range insertCount {
+		e.voidedBinds.Put(fmt.Sprintf("txn:%d:%d", e.nodeID, i), struct{}{})
+	}
+
+	count := e.voidedBinds.EntryCount()
+	if count > cap {
+		t.Fatalf("engine voidedBinds exceeded capacity: %d entries, capacity %d", count, cap)
+	}
+	t.Logf("after %d inserts: %d entries (capacity %d)", insertCount, count, cap)
+
+	// Verify read-your-writes within capacity: insert a fresh entry and
+	// immediately read it back. This is the path flushTx depends on —
+	// the Put and Get happen on the same goroutine within microseconds.
+	freshKey := "txn:fresh:ryw"
+	e.voidedBinds.Put(freshKey, struct{}{})
+	if _, ok := e.voidedBinds.Get(freshKey, 0); !ok {
+		t.Fatal("read-your-writes failed for fresh entry after overflow")
 	}
 }

--- a/effects/horizon_test.go
+++ b/effects/horizon_test.go
@@ -44,7 +44,7 @@ func newHorizonTestEngine() *Engine {
 		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
 		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
-		voidedBinds:       xsync.NewMap[string, struct{}](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(256)),
 	}
 	e.safety.Store(&safetyMap{defaultMode: UnsafeMode})
 	e.horizon = newHorizonSet(e, 500*time.Millisecond)

--- a/effects/snapshot.go
+++ b/effects/snapshot.go
@@ -397,7 +397,7 @@ func (e *Engine) reconstruct(key string, tips []Tip, currentTxID ...string) (*pb
 			if isInvisible != nil && isInvisible(eff.TxnId) {
 				return nil
 			}
-			if _, voided := e.voidedBinds.Load(eff.TxnId); voided {
+			if _, voided := e.voidedBinds.Get(eff.TxnId, 0); voided {
 				return nil
 			}
 			// Check if this bind competes with an already-won bind.

--- a/effects/snapshot_test.go
+++ b/effects/snapshot_test.go
@@ -116,7 +116,7 @@ func newSnapshotEngine(log *snapshotLog, cache StateCache) *Engine {
 		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
 		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
-		voidedBinds:       xsync.NewMap[string, struct{}](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(256)),
 	}
 	e.safety.Store(&safetyMap{defaultMode: UnsafeMode})
 	return e
@@ -1136,7 +1136,7 @@ func TestSubscriptionBootstrap_FetchesRemoteState(t *testing.T) {
 		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
 		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
-		voidedBinds:       xsync.NewMap[string, struct{}](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(256)),
 	}
 	remoteEngine.safety.Store(&safetyMap{defaultMode: UnsafeMode})
 
@@ -1178,7 +1178,7 @@ func TestSubscriptionBootstrap_FetchesRemoteState(t *testing.T) {
 		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
 		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
-		voidedBinds:       xsync.NewMap[string, struct{}](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(256)),
 	}
 	localEngine.safety.Store(&safetyMap{defaultMode: UnsafeMode})
 
@@ -1262,7 +1262,7 @@ func TestHandleRemote_SubscriptionEffect_SendsNack(t *testing.T) {
 		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
 		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
-		voidedBinds:       xsync.NewMap[string, struct{}](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(256)),
 	}
 	e.safety.Store(&safetyMap{defaultMode: UnsafeMode})
 
@@ -1316,7 +1316,7 @@ func TestHandleRemote_SubscriptionEffect_EmptyKey_SendsEmptyNack(t *testing.T) {
 		pendingTxTips:     xsync.NewMap[Tip, []Tip](),
 		txAbortCounts:     xsync.NewMap[string, *atomic.Int32](),
 		pendingBootstraps: xsync.NewMap[string, *bootstrapCollector](),
-		voidedBinds:       xsync.NewMap[string, struct{}](),
+		voidedBinds:       clox.NewCloxCache[string, struct{}](clox.ConfigFromCapacity(256)),
 	}
 	e.safety.Store(&safetyMap{defaultMode: UnsafeMode})
 


### PR DESCRIPTION
Fix #29 

## Solution

Replace the unbounded `xsync.Map` with a `CloxCache[string, struct{}]` instance configured with `ConfigFromCapacity(8192)`. CloxCache provides:

- **Bounded memory**: Entries are automatically evicted when capacity is reached, using protected-frequency eviction with LRU tiebreaking.
- **Read-your-writes**: Within capacity, a `Put` followed by `Get` on the same goroutine is guaranteed to succeed. This preserves the correctness of the `flushTx` path where `evaluateBindForkChoice` stores a txnID and `flushTx` checks it microseconds later.
- **No background goroutines**: Unlike a TTL-based approach, CloxCache evicts inline during `Put`, requiring no sweeper goroutine or stop channels.

The 8192-entry capacity is sufficient for the working set of active voided binds. Eviction of older entries is safe because all four read sites have independent correctness mechanisms (see `issue.md` for details).

## Safety Argument

**Capacity eviction correctness** — All four read sites are backed by independent mechanisms that handle cache misses:
- `reconstruct`: The `wonTips` map independently resolves competing binds via topological fork-choice ordering.
- `checkCompetingBinds`: Missing entries trigger re-evaluation via shared causal base checks, which is idempotent.
- `evaluateBindForkChoice`: Missing entries cause redundant fork-choice comparison, producing the same winner.
- `flushTx`: The `Put` and `Get` happen on the same goroutine within microseconds. With 8192 capacity, the entry cannot be evicted between these two operations.

**No import changes** — The `clox` import alias (`github.com/swytchdb/cache/cache`) was already used in `effect.go` for the `effectCache` field. The `xsync` import remains for the other `xsync.Map` fields (`pendingTxns`, `pendingTxTips`, etc.).

Co-authored-by: Grok <noreply@xai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory efficiency in transaction processing by implementing bounded state tracking. Replaced unbounded internal tracking mechanism with a capacity-limited system to prevent memory exhaustion during intensive operation. Enhanced regression testing validates proper memory bounds, transaction consistency, and data visibility guarantees under heavy load conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/swytchdb/cache/pull/30)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->