### PR TITLE
bisect: pre-BFS-refactor jepsen run

### DIFF
--- a/.github/jepsen-k8s/controller-pod.yaml
+++ b/.github/jepsen-k8s/controller-pod.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${RESOURCE_PREFIX}-controller
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: swytch-jepsen
+    swytch-jepsen/role: controller
+    swytch-jepsen/run-id: "${RUN_ID}"
+    swytch-jepsen/workload: "${WORKLOAD}"
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  containers:
+    - name: controller
+      image: ${JEPSEN_IMAGE}
+      imagePullPolicy: Always
+      # Wait for the workflow to drop the swytch binary and ssh key
+      # into /workspace, then run jepsen.
+      command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          echo "waiting for /workspace/.ready ..."
+          while [ ! -f /workspace/.ready ]; do sleep 1; done
+          export SWYTCH_BINARY=/workspace/swytch
+          export SSH_PRIVATE_KEY_PATH=/workspace/id_ed25519
+          chmod 0600 "$SSH_PRIVATE_KEY_PATH"
+          chmod +x "$SWYTCH_BINARY"
+          mkdir -p /workspace/store
+          ln -sfn /workspace/store /opt/jepsen/store
+          exec /usr/local/bin/run-jepsen
+      env:
+        - name: JEPSEN_REF
+          value: "${JEPSEN_REF}"
+        - name: JEPSEN_NODES
+          value: "${JEPSEN_NODES}"
+        - name: JEPSEN_WORKLOAD
+          value: "${JEPSEN_WORKLOAD}"
+        - name: JEPSEN_NEMESIS
+          value: "${JEPSEN_NEMESIS}"
+        - name: JEPSEN_TIME_LIMIT
+          value: "${JEPSEN_TIME_LIMIT}"
+        - name: JEPSEN_JOIN_DNS
+          value: "${JEPSEN_JOIN_DNS}"
+      # Burstable QoS, same rationale as node-pod.yaml.
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "8Gi"
+        limits:
+          memory: "8Gi"
+      volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+    # Sidecar that just sits on the workspace volume so the pod stays
+    # Running after the controller container exits. Without this the
+    # pod-phase flips to Succeeded/Failed and `kubectl cp` (which needs
+    # to exec tar inside a Running container) fails, stranding all
+    # store/ output — results.edn, history.{txt,html}, per-node logs,
+    # plots — none of which appear in `kubectl logs`.
+    - name: holder
+      image: ${JEPSEN_IMAGE}
+      imagePullPolicy: Always
+      command: ["/bin/bash", "-c", "trap 'exit 0' TERM; sleep 86400 & wait"]
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "64Mi"
+        limits:
+          memory: "128Mi"
+      volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+  volumes:
+    - name: workspace
+      emptyDir: {}

--- a/.github/jepsen-k8s/node-pod.yaml
+++ b/.github/jepsen-k8s/node-pod.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${RESOURCE_PREFIX}-node-${NODE_INDEX}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/part-of: swytch-jepsen
+    swytch-jepsen/role: node
+    swytch-jepsen/run-id: "${RUN_ID}"
+    swytch-jepsen/workload: "${WORKLOAD}"
+spec:
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 5
+  automountServiceAccountToken: false
+  containers:
+    - name: node
+      image: ${JEPSEN_IMAGE}
+      imagePullPolicy: Always
+      command: ["/usr/local/bin/run-sshd"]
+      ports:
+        - name: ssh
+          containerPort: 22
+      # Burstable QoS: low CPU request so the scheduler can place us
+      # on any node with headroom, no CPU limit so we can burn all
+      # idle cores on whichever node we land on. Memory is
+      # non-compressible so request==limit.
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "8Gi"
+        limits:
+          memory: "8Gi"
+      securityContext:
+        capabilities:
+          add: ["NET_ADMIN", "NET_RAW"]
+      volumeMounts:
+        - name: ssh-keys
+          mountPath: /etc/jepsen/keys
+          readOnly: true
+      readinessProbe:
+        tcpSocket:
+          port: 22
+        periodSeconds: 2
+  volumes:
+    - name: ssh-keys
+      secret:
+        secretName: ${RESOURCE_PREFIX}-ssh
+        defaultMode: 0400

--- a/.github/jepsen-k8s/ssh-secret.yaml
+++ b/.github/jepsen-k8s/ssh-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${RESOURCE_PREFIX}-ssh
+  namespace: ${NAMESPACE}
+  labels:
+    swytch-jepsen/run-id: "${RUN_ID}"
+    swytch-jepsen/workload: "${WORKLOAD}"
+type: Opaque
+data:
+  authorized_keys: ${SSH_AUTHORIZED_KEYS_B64}


### PR DESCRIPTION
Branch off 7aa1b87 (parent of #26 'Refactor DAG walking') to verify whether elle G1c / incompatible-order anomalies predate or postdate the BFS refactor.

Empty commit so the PR has a diff to trigger /jepsen against.