### PR TITLE
Remove UPX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install UPX
-        uses: crazy-max/ghaction-upx@v4
-        with:
-          install-only: true
-
       - uses: sigstore/cosign-installer@v3
       - uses: anchore/sbom-action/download-syft@v0
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,19 +32,6 @@ builds:
       - amd64
       - arm64
 
-upx:
-  - enabled: true
-    compress: best
-    lzma: true
-    ids:
-      - swytch
-    goos:
-      - linux
-      - windows
-    goarch:
-      - amd64
-      - arm64
-
 archives:
   - id: default
     formats: [tar.gz]


### PR DESCRIPTION
Removed UPX installation step from the release workflow.

Why:
- upx packed binaries must be fully extracted into RAM on each running copy and cannot share read-only segments mmap'd from disk
- upx increases false-positive detection risk by spyware and adware (I mean antivirus shitware)