### PR TITLE
Caddy storage

### DIFF
--- a/beacon/runtime.go
+++ b/beacon/runtime.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/swytchdb/swytch/cluster"
@@ -82,6 +83,24 @@ type RuntimeConfig struct {
 	// peers. Empty triggers auto-detection via DetectAdvertiseAddr.
 	AdvertiseAddr string
 
+	// AsyncJoin makes NewRuntime return as soon as the local engine and
+	// peer manager (QUIC listener) are up, running the beacon's blocking
+	// join — DNS discovery, symmetric-peer wait, membership convergence —
+	// in a background goroutine instead of before returning. The node
+	// serves immediately in solo mode and converges with peers as they
+	// become reachable.
+	//
+	// This trades the default's join-before-serve guarantee for
+	// availability: a caller that accepts writes before the background
+	// join completes may commit solo and replicate late. Enable it only
+	// where that is acceptable — e.g. the Caddy TLS-storage module, whose
+	// writes are LWW cert state, and whose Provision must return promptly
+	// so it does not stall the whole server's startup (and time out under
+	// systemd) when a peer is unreachable. Transports that must not serve
+	// against a synthetic topology (SQL/redis serializable paths) leave it
+	// false.
+	AsyncJoin bool
+
 	// Embedder durability seams, installed before the beacon starts so no emit
 	// or remote arrival races their wiring. They are how an embedder brings its
 	// own durable store (e.g. the cloud dataplane's internal S3): OnLocalEffect
@@ -109,6 +128,13 @@ type Runtime struct {
 	CloudSync   *cluster.CloudSync
 
 	cfg RuntimeConfig
+
+	// joinCancel/joinWG track an in-flight AsyncJoin goroutine so Stop can
+	// cancel it and wait for it to return before tearing down the peer
+	// manager and engine it touches. Both are zero-valued (nil / empty)
+	// when AsyncJoin is false, making Stop's drain a no-op.
+	joinCancel context.CancelFunc
+	joinWG     sync.WaitGroup
 }
 
 // NewRuntime builds and starts the engine. If cfg.ClusterPassphrase
@@ -301,13 +327,29 @@ func NewRuntime(cfg RuntimeConfig) (*Runtime, error) {
 		}
 	}
 
-	if err := b.Start(context.Background()); err != nil {
-		return nil, errors.Join(
-			fmt.Errorf("failed to start beacon: %w", err),
-			closeRuntimeOnError(rt),
-		)
+	if cfg.AsyncJoin {
+		// Local engine + QUIC listener are already up; run the blocking
+		// join in the background so callers (e.g. Caddy's Provision) return
+		// promptly and serve solo until peers converge. joinCtx lets Stop
+		// abort an in-flight join; joinWG lets it wait for the goroutine to
+		// return before closing the peer manager / engine the join uses.
+		joinCtx, joinCancel := context.WithCancel(context.Background())
+		rt.joinCancel = joinCancel
+		rt.Beacon = b
+		rt.joinWG.Go(func() {
+			if err := b.Start(joinCtx); err != nil {
+				log.Warn("cluster join did not complete; serving solo, will converge in background", "error", err)
+			}
+		})
+	} else {
+		if err := b.Start(context.Background()); err != nil {
+			return nil, errors.Join(
+				fmt.Errorf("failed to start beacon: %w", err),
+				closeRuntimeOnError(rt),
+			)
+		}
+		rt.Beacon = b
 	}
-	rt.Beacon = b
 
 	log.Info("cluster runtime ready",
 		"node_id", engine.NodeID(),
@@ -325,6 +367,14 @@ func NewRuntime(cfg RuntimeConfig) (*Runtime, error) {
 // still reach the upload outbox; PM before engine because broadcast close
 // paths reference the engine).
 func (r *Runtime) Stop() error {
+	// Drain an in-flight AsyncJoin first: b.Start touches the peer manager
+	// and engine, so it must fully return before we tear those down. No-op
+	// when AsyncJoin was false (joinCancel nil, joinWG empty).
+	if r.joinCancel != nil {
+		r.joinCancel()
+	}
+	r.joinWG.Wait()
+
 	var errs []error
 	if r.Beacon != nil {
 		r.Beacon.Stop()

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -41,6 +41,7 @@ which would fail because the parent module is `package main`.)
 {
     storage swytch {
         cluster_passphrase <secret>     # empty = single-node (no replication)
+        connection_secret <secret>      # Swytch Cloud durability; excludes cluster_passphrase + join
         join <dns-name>                 # peers resolve via DNS; optional
         cluster_port <num>              # QUIC port; default 7380/UDP
         cluster_advertise <addr:port>   # this node's reachable address; auto-detect if empty
@@ -68,6 +69,7 @@ JSON-encoded equivalents of the Caddyfile keywords:
   "storage": {
     "module": "swytch",
     "cluster_passphrase": "...",
+    "connection_secret": "...",
     "join": "...",
     "cluster_port": 7380,
     "cluster_advertise": "10.0.0.1:7380",
@@ -80,10 +82,15 @@ JSON-encoded equivalents of the Caddyfile keywords:
 ## Lifecycle notes
 
 - The embedded engine is a process-wide singleton. Caddy reloads reuse it;
-  changing `cluster_passphrase`, `join`, `cluster_port`, `cluster_advertise`,
-  or `key_prefix` at reload time is rejected — these are all baked into
-  the QUIC listener, TLS cert SAN, or peer-discovery state at startup and
-  there is no live-update path. Restart the process instead.
+  changing `cluster_passphrase`, `connection_secret`, `join`, `cluster_port`,
+  `cluster_advertise`, or `key_prefix` at reload time is rejected — these are
+  all baked into the QUIC listener, TLS cert SAN, or peer-discovery state at
+  startup and there is no live-update path. Restart the process instead.
+- `connection_secret` enables Swytch Cloud durability and is a self-contained
+  cluster identity: the cluster passphrase derives from it and peers come from
+  the cloud roster, so it is mutually exclusive with `cluster_passphrase` and
+  `join`. TLS state still replicates peer-to-peer; Cloud is the backstop that
+  rehydrates keys evicted from every live peer.
 - `lock_ttl` is per-storage and DOES take effect on the next reload.
 - Single-node mode (`cluster_passphrase` empty) is supported and useful
   for local development. No QUIC port is bound, no peer discovery runs.

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -76,6 +76,14 @@ type SwytchStorage struct {
 	// replication. Must match across every peer.
 	ClusterPassphrase string `json:"cluster_passphrase,omitempty"`
 
+	// ConnectionSecret enables Swytch Cloud durability. It is a self-contained
+	// cluster identity: the mTLS passphrase derives from it, so it is mutually
+	// exclusive with ClusterPassphrase, and peer discovery uses the cloud
+	// membership roster, so Join must be empty. When set, TLS state replicates
+	// peer-to-peer as usual and is additionally backed by Swytch Cloud, so a key
+	// evicted from every live peer is rehydrated from Cloud instead of lost.
+	ConnectionSecret string `json:"connection_secret,omitempty"`
+
 	// Join is the DNS name to discover peers.
 	// Empty is fine for single-node deployments.
 	Join string `json:"join,omitempty"`
@@ -134,9 +142,23 @@ func (s *SwytchStorage) CertMagicStorage() (certmagic.Storage, error) {
 func (s *SwytchStorage) Provision(ctx caddycore.Context) error {
 	repl := caddycore.NewReplacer()
 	s.ClusterPassphrase = repl.ReplaceAll(s.ClusterPassphrase, "")
+	s.ConnectionSecret = repl.ReplaceAll(s.ConnectionSecret, "")
 	s.Join = repl.ReplaceAll(s.Join, "")
 	s.ClusterAdvertise = repl.ReplaceAll(s.ClusterAdvertise, "")
 	s.KeyPrefix = repl.ReplaceAll(s.KeyPrefix, "")
+
+	if s.ConnectionSecret != "" {
+		// Swytch Cloud identity is self-contained: the mTLS passphrase derives
+		// from the secret, and peers come from the cloud roster. beacon.NewRuntime
+		// rejects both collisions, but catch them here so the operator gets a
+		// Caddyfile-level error instead of a runtime start failure.
+		if s.ClusterPassphrase != "" {
+			return fmt.Errorf("swytch storage: connection_secret is mutually exclusive with cluster_passphrase (the mTLS passphrase derives from the secret)")
+		}
+		if s.Join != "" {
+			return fmt.Errorf("swytch storage: connection_secret is mutually exclusive with join (peer discovery uses the cloud membership roster)")
+		}
+	}
 
 	if s.ClusterPort == 0 {
 		s.ClusterPort = defaultClusterPort
@@ -156,6 +178,7 @@ func (s *SwytchStorage) Provision(ctx caddycore.Context) error {
 
 	cfg := beacon.RuntimeConfig{
 		ClusterPassphrase: s.ClusterPassphrase,
+		ConnectionSecret:  s.ConnectionSecret,
 		JoinAddr:          s.Join,
 		ClusterPort:       s.ClusterPort,
 		AdvertiseAddr:     s.ClusterAdvertise,
@@ -176,8 +199,11 @@ func (s *SwytchStorage) Provision(ctx caddycore.Context) error {
 		// same host — and dial peers as a side effect of a read-only check.
 		// Caddy exposes no validate signal to modules, so drop into
 		// single-node mode: the engine still comes up (so storage-config
-		// validation succeeds) with no network activity.
+		// validation succeeds) with no network activity. ConnectionSecret is
+		// cleared too — it derives the passphrase and starts CloudSync, which
+		// dials Swytch Cloud.
 		cfg.ClusterPassphrase = ""
+		cfg.ConnectionSecret = ""
 		cfg.JoinAddr = ""
 	}
 	if err := claimRuntime(cfg, s.KeyPrefix); err != nil {
@@ -206,6 +232,7 @@ func (s *SwytchStorage) Cleanup() error {
 //
 //	storage swytch {
 //	    cluster_passphrase <pass>
+//	    connection_secret <secret>
 //	    join <dns>
 //	    cluster_port <num>
 //	    cluster_advertise <addr:port>
@@ -226,6 +253,11 @@ func (s *SwytchStorage) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.ArgErr()
 			}
 			s.ClusterPassphrase = d.Val()
+		case "connection_secret":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			s.ConnectionSecret = d.Val()
 		case "join":
 			if !d.NextArg() {
 				return d.ArgErr()
@@ -310,11 +342,12 @@ func claimRuntime(cfg beacon.RuntimeConfig, keyPrefix string) error {
 	if currentRuntime != nil {
 		prev := currentRuntime.cfg
 		if prev.ClusterPassphrase != cfg.ClusterPassphrase ||
+			prev.ConnectionSecret != cfg.ConnectionSecret ||
 			prev.JoinAddr != cfg.JoinAddr ||
 			prev.ClusterPort != cfg.ClusterPort ||
 			prev.AdvertiseAddr != cfg.AdvertiseAddr {
 			return fmt.Errorf("cluster configuration cannot change without restarting the process " +
-				"(passphrase/join/port/advertise differ from running instance)")
+				"(passphrase/connection_secret/join/port/advertise differ from running instance)")
 		}
 		if currentRuntime.keyPrefix != keyPrefix {
 			return fmt.Errorf("key_prefix cannot change without restarting the process "+

--- a/caddy/module.go
+++ b/caddy/module.go
@@ -27,6 +27,7 @@ package caddy
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -159,11 +160,41 @@ func (s *SwytchStorage) Provision(ctx caddycore.Context) error {
 		ClusterPort:       s.ClusterPort,
 		AdvertiseAddr:     s.ClusterAdvertise,
 		Logger:            ctx.Slogger(),
+		// Serve immediately; join the cluster in the background. Caddy gates
+		// its readiness (the systemd notify) on every module's Provision
+		// returning, so a blocking cluster join here stalls the whole
+		// server's startup — and times out under systemd — whenever a peer
+		// is unreachable. Solo-first + background convergence is the right
+		// trade for TLS storage, whose values are LWW cert state.
+		AsyncJoin: true,
+	}
+	if isConfigValidation() {
+		// `caddy validate` provisions every module (to surface config
+		// errors) but never starts serving and tears the config down
+		// immediately after. Standing up the cluster transport here would
+		// bind the QUIC port — colliding with an already-running node on the
+		// same host — and dial peers as a side effect of a read-only check.
+		// Caddy exposes no validate signal to modules, so drop into
+		// single-node mode: the engine still comes up (so storage-config
+		// validation succeeds) with no network activity.
+		cfg.ClusterPassphrase = ""
+		cfg.JoinAddr = ""
 	}
 	if err := claimRuntime(cfg, s.KeyPrefix); err != nil {
 		return fmt.Errorf("swytch storage: %w", err)
 	}
 	return nil
+}
+
+// isConfigValidation reports whether this process was invoked as
+// `caddy validate`. Caddy runs module Provision during validation just as
+// it does for a real run, but with no serving and an immediate teardown,
+// and exposes no in-context flag distinguishing the two — so we inspect the
+// subcommand. Defaults to false (serve) for any other or embedded
+// invocation; an in-process admin-API validate is already safe because it
+// reuses the running singleton runtime rather than binding a second one.
+func isConfigValidation() bool {
+	return len(os.Args) > 1 && os.Args[1] == "validate"
 }
 
 // Cleanup releases this module's reference on the runtime.

--- a/caddy/storage_test.go
+++ b/caddy/storage_test.go
@@ -395,6 +395,22 @@ func TestCaddyfile_AllOptions(t *testing.T) {
 	}
 }
 
+func TestCaddyfile_ConnectionSecret(t *testing.T) {
+	s, err := parseCaddyfile(t, `swytch {
+		connection_secret cloud-secret-xyz
+		cluster_port 9999
+	}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if s.ConnectionSecret != "cloud-secret-xyz" {
+		t.Errorf("ConnectionSecret: got %q", s.ConnectionSecret)
+	}
+	if s.ClusterPassphrase != "" {
+		t.Errorf("ClusterPassphrase should be empty in cloud mode, got %q", s.ClusterPassphrase)
+	}
+}
+
 func TestCaddyfile_Empty(t *testing.T) {
 	s, err := parseCaddyfile(t, `swytch {
 	}`)
@@ -485,6 +501,12 @@ func TestClaimRuntime_RefcountAndIncompatibility(t *testing.T) {
 	// is already bound and the TLS cert SAN baked in.
 	if err := claimRuntime(beacon.RuntimeConfig{AdvertiseAddr: "10.0.0.1:7380"}, "__caddy:"); err == nil {
 		t.Fatalf("expected error for incompatible advertise")
+	}
+
+	// Conflicting connection_secret on reclaim must error — it derives the
+	// cluster identity and is baked in at NewRuntime time.
+	if err := claimRuntime(beacon.RuntimeConfig{ConnectionSecret: "cloud-x"}, "__caddy:"); err == nil {
+		t.Fatalf("expected error for incompatible connection_secret")
 	}
 
 	// Release back to zero — runtime stops.

--- a/caddy/storage_test.go
+++ b/caddy/storage_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -503,5 +504,37 @@ func TestClaimRuntime_RefcountAndIncompatibility(t *testing.T) {
 	// Extra release on empty is a no-op.
 	if err := releaseRuntime(); err != nil {
 		t.Errorf("extra release: %v", err)
+	}
+}
+
+// TestIsConfigValidation locks the subcommand-based detection that makes
+// Provision drop into single-node mode under `caddy validate` (no QUIC
+// bind, no peer dial). Caddy exposes no in-context validate flag, so this
+// argv check is the whole signal — keep it honest.
+func TestIsConfigValidation(t *testing.T) {
+	saved := os.Args
+	t.Cleanup(func() { os.Args = saved })
+
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"validate", []string{"caddy", "validate", "--config", "Caddyfile"}, true},
+		{"run", []string{"caddy", "run", "--config", "Caddyfile"}, false},
+		{"start", []string{"caddy", "start"}, false},
+		{"no subcommand", []string{"caddy"}, false},
+		{"empty", nil, false},
+		// Only the subcommand slot counts — a later "validate" arg (e.g. a
+		// path) must not trip it.
+		{"validate as later arg", []string{"caddy", "run", "validate"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Args = tc.args
+			if got := isConfigValidation(); got != tc.want {
+				t.Errorf("isConfigValidation() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Swytch Cloud durability configuration through the `connection_secret` setting.
  * Caddy can now start while cluster discovery continues in the background, allowing solo operation during convergence.
  * Configuration validation avoids performing cluster or network actions.

* **Bug Fixes**
  * Improved shutdown handling to safely complete background cluster discovery before stopping services.

* **Documentation**
  * Updated Caddy configuration examples and lifecycle guidance for `connection_secret`, including compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->