### PR TITLE
[opt] Make less allocations and cloxcache improvements

### DIFF
--- a/cache/cloxcache.go
+++ b/cache/cloxcache.go
@@ -20,6 +20,16 @@
 // Package cache provides a lock-free adaptive in-memory cache implementation.
 // CloxCache uses protected-freq eviction: items with high frequency are protected,
 // with LRU as a tiebreaker among same-frequency items.
+//
+// Boundary conditions on the policy's edge over plain LRU (measured against
+// offline Belady replay; see trace_replay_test.go): the win lives at
+// cache-size/working-set ratios of roughly 0.3–0.8. Below ~0.25 every policy
+// produces near-identical contents (the cache fully flushes each cycle);
+// above ~1 plain recency already retains the working set. Any hot tier above
+// this cache (a client cache, CDN, an L1) skims precisely the frequency skew
+// protection feeds on, so the policy's value concentrates in whatever skew
+// the residual traffic still carries and shrinks toward LRU-parity as upper
+// tiers deepen. Benchmark claims should state these conditions.
 package cache
 
 import (
@@ -41,9 +51,15 @@ const (
 	// initialFreq is the starting frequency for new keys
 	initialFreq = 1
 
-	// defaultProtectedFreqThreshold - items with freq > this are protected from eviction.
-	// Analysis shows freq>=3 items are likely to return
-	defaultProtectedFreqThreshold = 2
+	// defaultProtectedFreqThreshold - items with freq > this are protected
+	// from eviction. k = 0 means protection is off: every live entry is a
+	// candidate and eviction is pure LRU. That is the starting state —
+	// protection must earn its way in via the graduation probe rather than
+	// being presumed, so a cache serving a low-reuse workload never starts
+	// out worse than plain LRU. (A floor of 1 still shields every key that
+	// was ever read once; on a reuse-≈1.3 real trace that made the entire
+	// already-served cohort untouchable.)
+	defaultProtectedFreqThreshold = 0
 
 	// adaptiveCheckInterval - check graduation rate every N evictions
 	adaptiveCheckInterval = 1000
@@ -64,6 +80,26 @@ const (
 	// Window size for measuring hit rate effect of k changes
 	hitRateWindowSize = 2000 // smaller window = faster feedback
 
+	// defaultDecayInterval - floor for the per-shard eviction count between
+	// eviction-driven frequency decay steps. Every step walks live entries
+	// down by 1 (floor 1) as the eviction scan visits them, so a saturated
+	// entry that stops earning accesses forgets instead of squatting on its
+	// slot after the workload moves on. The auto default scales the interval
+	// with per-shard capacity (max(8, capacity/2), see decayIntervalFor):
+	// the Belady replay's optimum — forget-from-saturation over ~50–120
+	// evictions on 3–32-slot shards — is ≈7 capacity-turnovers, and it is the
+	// turnover count that generalizes, not the absolute eviction count. A
+	// fixed ~100-eviction timescale on a 128-entry shard is under one
+	// turnover, so a single capacity-sized flood erases all protection and
+	// the policy replays bit-identical to LRU (the scan-burst fixture catches
+	// this). Linear −1 rather than halving: halving's first step (15→7)
+	// erases the hot-vs-warm ranking exactly when a starved cache needs it,
+	// while −1 is rank-preserving and beat halving at equal timescale in
+	// every configuration tested. The clock is evictions, never wall time: an
+	// idle cache must forget nothing. Decaying too fast degrades into plain
+	// LRU (never below it); too slowly re-introduces squatters — a forgiving
+	// knob.
+	defaultDecayInterval = 8
 )
 
 // Key is a type constraint for cache keys.
@@ -119,11 +155,12 @@ type CloxCache[K Key, V any] struct {
 	shardBits int
 
 	// Configuration
-	collectStats bool
-	sweepPercent int                        // Percentage of shard to scan during eviction (1-100)
-	sizeFunc     func(key K, value V) int64 // optional byte size calculator
-	evictDecider func(key K, value V) bool  // optional eviction veto (true = may evict, false = pinned)
-	evictNotify  func(key K, value V)       // optional post-eviction notification (ghost-conversion or full unlink)
+	collectStats  bool
+	sweepPercent  int                        // Percentage of shard to scan during eviction (1-100)
+	decayInterval int64                      // evictions per freq-decay step (0 = auto-scale, -1 = disabled)
+	sizeFunc      func(key K, value V) int64 // optional byte size calculator
+	evictDecider  func(key K, value V) bool  // optional eviction veto (true = may evict, false = pinned)
+	evictNotify   func(key K, value V)       // optional post-eviction notification (ghost-conversion or full unlink)
 
 	// Metrics (only updated when collectStats is true)
 	hits        atomic.Uint64
@@ -174,7 +211,11 @@ type shard[K Key, V any] struct {
 	reachedProtected   atomic.Uint64 // items whose freq crossed the shard's current k (graduated)
 	lastAdaptCheck     atomic.Uint64 // eviction count at last adaptation check
 	prevHitRate        atomic.Uint64 // previous window hit rate * 10000 (gradient descent on hit rate)
-	_                  [8]byte       // pad to 64
+	decayClock         atomic.Uint64 // evictions since the last decay-epoch step (reset each step)
+
+	// cache line 5: decay epoch (eviction only)
+	decayEpoch atomic.Uint64 // completed decay intervals; nodes absorb the delta on sweep visit
+	_          [56]byte      // pad to 64
 }
 
 // Compile-time assertion: shard size must be a multiple of 64 bytes (cache line).
@@ -190,7 +231,11 @@ type recordNode[K Key, V any] struct {
 	keyHash    uint64                           // fast hash comparison
 	freq       atomic.Int32                     // access frequency (negative = ghost)
 	lastAccess atomic.Uint64                    // per-shard monotonic timestamp for LRU tiebreaking
-	key        K
+	// lastDecayEpoch is the shard decay epoch this node last absorbed; the
+	// eviction scan steps freq down by the elapsed epochs on visit, so decay
+	// costs O(1) per touched node instead of a global walk (see decayNode).
+	lastDecayEpoch atomic.Uint64
+	key            K
 }
 
 // SizeFunc returns the size in bytes of a key-value pair.
@@ -205,6 +250,14 @@ type Config struct {
 	CollectStats  bool // Enable hit/miss/eviction counters
 	// (recommend: 15 for temporal workloads and low latency)
 	SweepPercent int // Percentage of shard to scan during eviction
+	// DecayInterval is the number of evictions (per shard) between
+	// eviction-driven frequency decay steps: 0 auto-scales with per-shard
+	// capacity (max(8, capacity/2) — forget-from-saturation ≈ 7 capacity
+	// turnovers), negative disables decay. Without decay, an entry that
+	// saturated freq while hot squats on a slot after the workload moves on
+	// (measured on a sliding-window trace: 50.8% hit rate vs plain LRU's
+	// 89.9%).
+	DecayInterval int
 }
 
 // NewCloxCache creates a new cache with the given configuration
@@ -232,13 +285,19 @@ func NewCloxCache[K Key, V any](cfg Config) *CloxCache[K, V] {
 		sweepPercent = 100
 	}
 
+	decayInterval := int64(cfg.DecayInterval)
+	if decayInterval < 0 {
+		decayInterval = -1
+	}
+
 	c := &CloxCache[K, V]{
-		numShards:    cfg.NumShards,
-		shardBits:    bits.Len(uint(cfg.NumShards - 1)),
-		shards:       make([]shard[K, V], cfg.NumShards),
-		stop:         make(chan struct{}),
-		collectStats: cfg.CollectStats,
-		sweepPercent: sweepPercent,
+		numShards:     cfg.NumShards,
+		shardBits:     bits.Len(uint(cfg.NumShards - 1)),
+		shards:        make([]shard[K, V], cfg.NumShards),
+		stop:          make(chan struct{}),
+		collectStats:  cfg.CollectStats,
+		sweepPercent:  sweepPercent,
+		decayInterval: decayInterval,
 	}
 
 	totalCapacity := cfg.Capacity
@@ -314,8 +373,15 @@ func (c *CloxCache[K, V]) Get(key K, offset uint64) (V, bool) {
 				if node.freq.CompareAndSwap(f, f+1) {
 					// Track when items cross into protected status (freq > k)
 					// This happens when freq goes from k to k+1
-					// Only count when at capacity (under eviction pressure)
-					if f == shard.k.Load() && shard.entryCount.Load() >= shard.capacity.Load() {
+					// Only count when at capacity (under eviction pressure).
+					// At k=0 (protection off) every successful bump counts,
+					// not just a crossing: the question there is "does enough
+					// recurrence exist to pay for protection at all", and
+					// once-per-residency crossings can't push the rate past
+					// rateHigh even on a hot-set workload (measured ≈0.25 on
+					// scan-burst — k never climbed and the policy stayed LRU).
+					// Resident hits per eviction can.
+					if kk := shard.k.Load(); (kk == 0 || f == kk) && shard.entryCount.Load() >= shard.capacity.Load() {
 						shard.reachedProtected.Add(1)
 					}
 					// Only update timestamp when we successfully bumped freq
@@ -415,6 +481,11 @@ func (c *CloxCache[K, V]) Put(key K, value V) (success bool, evictedKey K, evict
 					node.value.Store(value)
 					node.freq.Store(promotedFreq)
 					node.lastAccess.Store(shard.timestamp.Add(1))
+					// The ghost period is not decay debt: without this reset the
+					// promoted freq would absorb every epoch spent as a ghost and
+					// collapse to the floor on the next sweep visit, erasing the
+					// warm restart the ghost exists to provide.
+					node.lastDecayEpoch.Store(shard.decayEpoch.Load())
 					shard.ghostCount.Add(-1)
 					shard.entryCount.Add(1)
 					return true, k, 0, 0
@@ -442,7 +513,9 @@ func (c *CloxCache[K, V]) Put(key K, value V) (success bool, evictedKey K, evict
 		}
 	}
 
-	// Insert at head
+	// Insert at head. The decay epoch starts at "now" so the new node only
+	// absorbs decay accrued during its own residency.
+	newNode.lastDecayEpoch.Store(shard.decayEpoch.Load())
 	head := slot.Load()
 	newNode.next.Store(head)
 	slot.Store(newNode)
@@ -499,8 +572,9 @@ func (c *CloxCache[K, V]) PutBack(key K, value V, oldSize int64) (success bool, 
 					break
 				}
 				if node.freq.CompareAndSwap(f, f+1) {
-					// Track graduation if crossing threshold
-					if f == shard.k.Load() && shard.entryCount.Load() >= shard.capacity.Load() {
+					// Track graduation if crossing threshold (at k=0 every
+					// bump counts; see the Get path)
+					if kk := shard.k.Load(); (kk == 0 || f == kk) && shard.entryCount.Load() >= shard.capacity.Load() {
 						shard.reachedProtected.Add(1)
 					}
 					break
@@ -595,6 +669,43 @@ func (c *CloxCache[K, V]) Evict(key K) bool {
 	return false
 }
 
+// decayIntervalFor returns the evictions-per-decay-step for a shard: the
+// configured value when set, otherwise auto-scaled to per-shard capacity so
+// forget-from-saturation stays ≈7 capacity-turnovers regardless of shard
+// size. 0 means decay is disabled.
+func (c *CloxCache[K, V]) decayIntervalFor(shard *shard[K, V]) uint64 {
+	switch {
+	case c.decayInterval > 0:
+		return uint64(c.decayInterval)
+	case c.decayInterval < 0:
+		return 0
+	}
+	return max(defaultDecayInterval, uint64(shard.capacity.Load())/2)
+}
+
+// decayNode absorbs a node's pending eviction-driven frequency decay: one −1
+// step per decay epoch elapsed since the node was last visited, floor 1.
+// Ghosts are exempt — their forgetting is ghost turnover. The CAS on
+// lastDecayEpoch elects a single decayer per epoch; the freq CAS loop rides
+// out concurrent Get bumps.
+func decayNode[K Key, V any](node *recordNode[K, V], epoch uint64) {
+	last := node.lastDecayEpoch.Load()
+	if last >= epoch || !node.lastDecayEpoch.CompareAndSwap(last, epoch) {
+		return
+	}
+	steps := epoch - last
+	for {
+		f := node.freq.Load()
+		if f <= 1 {
+			return
+		}
+		nf := f - int32(min(steps, uint64(f-1)))
+		if node.freq.CompareAndSwap(f, nf) {
+			return
+		}
+	}
+}
+
 // evictFromShard uses protected-freq eviction with LRU tiebreaking.
 // Called during Put when shard is over capacity. Caller must hold shard lock.
 // Returns the number of entries evicted (0 or 1).
@@ -608,6 +719,7 @@ func (c *CloxCache[K, V]) Evict(key K) bool {
 func (c *CloxCache[K, V]) evictFromShard(shardID, slotsPerShard int) int {
 	shard := &c.shards[shardID]
 	k := shard.k.Load()
+	epoch := shard.decayEpoch.Load()
 
 	// Calculate scan range
 	maxScan := max(slotsPerShard*c.sweepPercent/100, 1)
@@ -654,6 +766,13 @@ func (c *CloxCache[K, V]) evictFromShard(shardID, slotsPerShard int) int {
 				continue
 			}
 
+			// Absorb pending eviction-driven decay before judging
+			// protection: the freq that matters below is the decayed one.
+			if epoch > 0 {
+				decayNode(node, epoch)
+				freq = node.freq.Load()
+			}
+
 			// Pin check: skip live entries the decider rejects so they
 			// never become an eviction candidate.
 			if c.evictDecider != nil && !c.evictDecider(node.key, node.value.Load().(V)) {
@@ -662,8 +781,11 @@ func (c *CloxCache[K, V]) evictFromShard(shardID, slotsPerShard int) int {
 				continue
 			}
 
-			// Track LRU among low-freq items (freq <= k, unprotected)
-			if freq <= k && access < lowFreqAccess {
+			// Track LRU among low-freq items (freq <= k, unprotected).
+			// k == 0 is explicit "protection off": every live entry is a
+			// candidate and eviction is pure LRU (freq <= 0 would match
+			// nobody and invert the meaning into "protect everyone").
+			if (k == 0 || freq <= k) && access < lowFreqAccess {
 				lowFreqVictim = node
 				lowFreqPrev = prev
 				lowFreqSlot = slot
@@ -791,10 +913,28 @@ func (c *CloxCache[K, V]) evictFromShard(shardID, slotsPerShard int) int {
 		c.evictNotify(victim.key, notifyValue)
 	}
 
-	// Periodically adapt k based on graduation rate
+	// Advance the decay clock: forgetting is eviction-clocked, never
+	// wall-clocked, so an idle cache forgets nothing. The explicit epoch
+	// counter (rather than clock/interval division) keeps epochs monotonic
+	// when the auto-scaled interval moves with SetCapacity.
+	if interval := c.decayIntervalFor(shard); interval > 0 && shard.decayClock.Add(1) >= interval {
+		shard.decayClock.Store(0)
+		shard.decayEpoch.Add(1)
+	}
+
+	// Periodically adapt k based on graduation rate. Gated on a completed
+	// hit-rate window: once the eviction interval arms, the k step still
+	// waits until windowOps reaches a full window, so adaptation is strictly
+	// change → measure → learn — every k step is evaluated over exactly one
+	// window and lastKDirection is never overwritten by an unmeasured call.
+	// Without the gate, several k steps land inside one measurement window
+	// whenever evictions outpace probes — exactly when the cache is under
+	// pressure — and the gradient learns a hit-rate delta attributed to only
+	// the most recent direction. lastAdaptCheck is not advanced while gated,
+	// so the check stays armed until the window completes.
 	totalEvictions := shard.evictedUnprotected.Load() + shard.evictedProtected.Load()
 	lastCheck := shard.lastAdaptCheck.Load()
-	if totalEvictions-lastCheck >= adaptiveCheckInterval {
+	if totalEvictions-lastCheck >= adaptiveCheckInterval && shard.windowOps.Load() >= hitRateWindowSize {
 		if shard.lastAdaptCheck.CompareAndSwap(lastCheck, totalEvictions) {
 			c.adaptThreshold(shard)
 		}
@@ -878,9 +1018,12 @@ func (c *CloxCache[K, V]) adaptThreshold(shard *shard[K, V]) {
 	rateHigh := float64(shard.rateHigh.Load()) / 10000.0
 
 	var kDirection int32 = 0
-	if rate < rateLow && currentK > 1 {
-		// Very few items graduating - protection isn't helping
-		// Lower k, but never below 1 (need freq>=2 protection to allow graduation)
+	if rate < rateLow && currentK > 0 {
+		// Very few items graduating - protection isn't helping. k may walk
+		// all the way to 0 (protection off, pure LRU): when graduation
+		// collapses, LRU IS the correct policy and the adapter must be able
+		// to reach it. The graduation probe keeps counting 1→2 crossings at
+		// k=0, so a workload that develops skew climbs back out.
 		shard.k.Store(currentK - 1)
 		kDirection = -1
 	} else if rate > rateHigh && currentK < maxFrequency-1 {

--- a/cache/policy_regression_test.go
+++ b/cache/policy_regression_test.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Swytch Labs BV
+ *
+ * This file is part of Swytch.
+ *
+ * Swytch is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Swytch is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Swytch. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cache
+
+import (
+	"fmt"
+	"testing"
+)
+
+// findNode scans every shard chain for key, ghosts included (Get hides them).
+// Test-only; not concurrency-safe.
+func findNode[K Key, V any](c *CloxCache[K, V], key K) *recordNode[K, V] {
+	for si := range c.shards {
+		sh := &c.shards[si]
+		for i := range sh.slots {
+			for n := sh.slots[i].Load(); n != nil; n = n.next.Load() {
+				if n.key == key {
+					return n
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// TestEvictGhostTrimOrder pins the ghost-trim order: at ghost capacity, the
+// oldest EXISTING ghost is trimmed to make room before the fresh victim is
+// ghosted. The inverted order (ghost first, then trim the LRU ghost) is
+// refactor-bait that survives review: the victim was chosen as LRU, so its
+// recency is near-oldest, and the just-created ghost is almost always the one
+// trimmed — ghost memory freezes on a stale early cohort, every returning key
+// re-admits at freq 1 like a stranger, and the policy quietly becomes
+// LRU-with-overhead (the colibri C port shipped exactly this inversion).
+func TestEvictGhostTrimOrder(t *testing.T) {
+	// 1 shard, 8 slots, capacity 4 → ghostCapacity = min(8-4, 4) = 4.
+	c := NewCloxCache[string, int](Config{
+		NumShards: 1, SlotsPerShard: 8, Capacity: 4,
+		SweepPercent: 100, DecayInterval: -1,
+	})
+	defer c.Close()
+
+	// The victim-to-be goes in first so its recency predates every ghost's;
+	// the decider pins it while the fodder churn fills the ghost cache.
+	pinned := "victim"
+	c.SetEvictDecider(func(k string, _ int) bool { return k != pinned })
+	c.Put("victim", 0)
+
+	// f0..f2 fill the shard; f3..f6 each evict the LRU fodder into a ghost.
+	for i := range 7 {
+		c.Put(fmt.Sprintf("fodder-%d", i), i)
+	}
+	if got := c.shards[0].ghostCount.Load(); got != 4 {
+		t.Fatalf("ghostCount = %d; want 4 (at capacity)", got)
+	}
+
+	// Unpin and insert once more: the victim is the LRU live entry and its
+	// recency is older than all existing ghosts — the exact scenario where the
+	// buggy order trims the fresh ghost instead of the oldest one.
+	pinned = ""
+	c.Put("fodder-7", 7)
+
+	if got := c.shards[0].ghostCount.Load(); got != 4 {
+		t.Fatalf("ghostCount = %d after trim+ghost; want 4 (net unchanged)", got)
+	}
+	if n := findNode(c, "victim"); n == nil || n.freq.Load() >= 0 {
+		t.Fatal("fresh victim must survive as a ghost")
+	}
+	if n := findNode(c, "fodder-0"); n != nil {
+		t.Fatal("oldest existing ghost must be the one trimmed")
+	}
+	for i := 1; i <= 3; i++ {
+		if n := findNode(c, fmt.Sprintf("fodder-%d", i)); n == nil || n.freq.Load() >= 0 {
+			t.Fatalf("younger ghost fodder-%d must survive the trim", i)
+		}
+	}
+}
+
+// TestEvictionDrivenDecayStepsFreqDown verifies eviction-driven frequency
+// decay: an entry that saturated freq while hot steps down by 1 per elapsed
+// decay epoch as the eviction scan visits it, and decay disabled leaves freq
+// untouched. The clock is evictions, so an idle cache forgets nothing.
+func TestEvictionDrivenDecayStepsFreqDown(t *testing.T) {
+	run := func(decayInterval int) int32 {
+		c := NewCloxCache[string, int](Config{
+			NumShards: 1, SlotsPerShard: 512, Capacity: 16,
+			SweepPercent: 100, DecayInterval: decayInterval,
+		})
+		defer c.Close()
+		// Pin a protected class so the hot entry is never a victim; the
+		// default k=0 (pure LRU) would evict it as the oldest entry.
+		c.shards[0].k.Store(2)
+
+		c.Put("hot", 0)
+		for range 30 {
+			c.Get("hot", 0)
+		}
+		if got := findNode(c, "hot").freq.Load(); got != maxFrequency {
+			t.Fatalf("hot freq = %d after saturation; want %d", got, maxFrequency)
+		}
+
+		// 150 one-shot puts drive ~135 evictions: with interval 100 that is one
+		// decay epoch; the hot entry — protected, never a victim — is visited by
+		// every full-shard scan and must absorb exactly one −1 step.
+		for i := range 150 {
+			c.Put(fmt.Sprintf("churn-%d", i), i)
+		}
+		return findNode(c, "hot").freq.Load()
+	}
+
+	if got := run(100); got != maxFrequency-1 {
+		t.Fatalf("hot freq = %d after one decay epoch; want %d", got, maxFrequency-1)
+	}
+	if got := run(-1); got != maxFrequency {
+		t.Fatalf("hot freq = %d with decay disabled; want %d untouched", got, maxFrequency)
+	}
+}

--- a/cache/trace_replay_test.go
+++ b/cache/trace_replay_test.go
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2026 Swytch Labs BV
+ *
+ * This file is part of Swytch.
+ *
+ * Swytch is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Swytch is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Swytch. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Trace-replay harness: replays a request trace through plain LRU, the real
+// CloxCache, and clairvoyant Belady OPT (with bypass), and scores individual
+// eviction decisions against hindsight. Hit rate alone is a proxy — two
+// policies can hit equally while sacrificing different entries — so the
+// discriminating metrics are: excess misses over OPT; suboptimal-eviction
+// rate (victim re-requested before some other then-resident key — a choice
+// Belady would not make); victim return rate; and time-to-return. Wall-clock
+// benchmarks are noise on I/O-bound systems (a 3.1× decode spread was
+// observed between identical binaries twenty minutes apart); these
+// trace-derived signals are stable and found every real bug the colibri port
+// hit. The three synthetics below are adversarial regression fixtures:
+// scan-burst (protection should approach OPT while LRU thrashes), zipf
+// (protection should win modestly), and sliding-window drift (the squatter
+// detector — undecayed protection collapses; decayed must track LRU).
+package cache
+
+import (
+	"container/list"
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+// occIndex maps each key to its sorted occurrence positions in the trace.
+type occIndex map[uint64][]int
+
+func buildOcc(trace []uint64) occIndex {
+	occ := make(occIndex)
+	for i, k := range trace {
+		occ[k] = append(occ[k], i)
+	}
+	return occ
+}
+
+// nextAfter returns the first position strictly after pos at which key is
+// requested again, or math.MaxInt if it never returns.
+func (o occIndex) nextAfter(key uint64, pos int) int {
+	lst := o[key]
+	if i := sort.SearchInts(lst, pos+1); i < len(lst) {
+		return lst[i]
+	}
+	return math.MaxInt
+}
+
+// decisionMetrics scores individual eviction decisions against hindsight.
+type decisionMetrics struct {
+	evictions     int
+	victimReturns int   // victims re-requested at any later point
+	suboptEvicts  int   // victim returned before some then-resident key would have
+	ttrSum        int64 // total positions until a returning victim came back
+}
+
+func (m decisionMetrics) victimReturnRate() float64 {
+	if m.evictions == 0 {
+		return 0
+	}
+	return float64(m.victimReturns) / float64(m.evictions)
+}
+
+func (m decisionMetrics) suboptRate() float64 {
+	if m.evictions == 0 {
+		return 0
+	}
+	return float64(m.suboptEvicts) / float64(m.evictions)
+}
+
+func (m decisionMetrics) meanTimeToReturn() float64 {
+	if m.victimReturns == 0 {
+		return 0
+	}
+	return float64(m.ttrSum) / float64(m.victimReturns)
+}
+
+// scorer shadows a policy's live set and grades each eviction as it happens.
+type scorer struct {
+	occ      occIndex
+	resident map[uint64]struct{}
+	m        decisionMetrics
+}
+
+func newScorer(occ occIndex, capacity int) *scorer {
+	return &scorer{occ: occ, resident: make(map[uint64]struct{}, capacity)}
+}
+
+func (s *scorer) admit(key uint64) { s.resident[key] = struct{}{} }
+
+func (s *scorer) evict(key uint64, pos int) {
+	delete(s.resident, key)
+	s.m.evictions++
+	vNext := s.occ.nextAfter(key, pos)
+	if vNext == math.MaxInt {
+		return
+	}
+	s.m.victimReturns++
+	s.m.ttrSum += int64(vNext - pos)
+	// Suboptimal iff some still-resident key's next use is farther than the
+	// victim's: Belady would have sacrificed that key instead.
+	for rk := range s.resident {
+		if s.occ.nextAfter(rk, pos) > vNext {
+			s.m.suboptEvicts++
+			return
+		}
+	}
+}
+
+// replayLRU replays the trace through a plain LRU of the given capacity.
+func replayLRU(trace []uint64, capacity int, occ occIndex) (int, decisionMetrics) {
+	s := newScorer(occ, capacity)
+	l := list.New()
+	elems := make(map[uint64]*list.Element, capacity)
+	hits := 0
+	for i, k := range trace {
+		if el, ok := elems[k]; ok {
+			hits++
+			l.MoveToFront(el)
+			continue
+		}
+		if l.Len() >= capacity {
+			back := l.Back()
+			victim := back.Value.(uint64)
+			delete(elems, victim)
+			l.Remove(back)
+			s.evict(victim, i)
+		}
+		elems[k] = l.PushFront(k)
+		s.admit(k)
+	}
+	return hits, s.m
+}
+
+// replayOPT replays the trace through clairvoyant Belady with bypass: on a
+// miss at capacity it evicts the resident with the farthest next use, unless
+// the incoming key's own next use is farther still — then it bypasses
+// admission entirely. This is the offline optimum any online policy is scored
+// against.
+func replayOPT(trace []uint64, capacity int) int {
+	// next[i] = position of the next request for trace[i], or MaxInt.
+	next := make([]int, len(trace))
+	lastSeen := make(map[uint64]int, capacity)
+	for i := len(trace) - 1; i >= 0; i-- {
+		if p, ok := lastSeen[trace[i]]; ok {
+			next[i] = p
+		} else {
+			next[i] = math.MaxInt
+		}
+		lastSeen[trace[i]] = i
+	}
+
+	resident := make(map[uint64]int, capacity) // key → next use
+	hits := 0
+	for i, k := range trace {
+		if _, ok := resident[k]; ok {
+			hits++
+			resident[k] = next[i]
+			continue
+		}
+		if len(resident) < capacity {
+			resident[k] = next[i]
+			continue
+		}
+		var worstKey uint64
+		worst := -1
+		for rk, rn := range resident {
+			if rn > worst {
+				worst, worstKey = rn, rk
+			}
+		}
+		if next[i] >= worst {
+			continue // bypass: the incoming key is the farthest-future of them all
+		}
+		delete(resident, worstKey)
+		resident[k] = next[i]
+	}
+	return hits
+}
+
+// replayClox replays the trace through a real CloxCache, logging every
+// eviction decision (ghost conversion or full unlink both leave the live set)
+// through the scorer via the evict-notify hook.
+func replayClox(trace []uint64, cfg Config, occ occIndex) (int, decisionMetrics) {
+	c := NewCloxCache[uint64, int](cfg)
+	defer c.Close()
+
+	s := newScorer(occ, cfg.Capacity)
+	pos := 0
+	c.SetEvictNotify(func(k uint64, _ int) { s.evict(k, pos) })
+
+	hits := 0
+	for i, k := range trace {
+		pos = i
+		if _, ok := c.Get(k, 0); ok {
+			hits++
+			continue
+		}
+		c.Put(k, 0)
+		s.admit(k)
+	}
+	return hits, s.m
+}
+
+// replayCfg is the fixture cache: 256 entries across 2 shards, full-shard
+// sweeps for victim selectivity, default decay. Trace working sets are sized
+// against this to land in the 0.3–0.8 capacity/working-set band where policy
+// differences are visible (see the package comment's boundary conditions).
+func replayCfg() Config {
+	return Config{NumShards: 2, SlotsPerShard: 256, Capacity: 256, SweepPercent: 100}
+}
+
+func logReplay(t *testing.T, name string, ops, lruHits, cloxHits, optHits int, lruM, cloxM decisionMetrics) {
+	t.Helper()
+	pct := func(h int) float64 { return 100 * float64(h) / float64(ops) }
+	t.Logf("%s: hit rate LRU %.1f%% / clox %.1f%% / OPT %.1f%%", name, pct(lruHits), pct(cloxHits), pct(optHits))
+	t.Logf("%s: excess misses over OPT: LRU %d, clox %d", name, optHits-lruHits, optHits-cloxHits)
+	t.Logf("%s: subopt-evict rate LRU %.1f%% clox %.1f%% | victim-return LRU %.1f%% clox %.1f%% | mean-ttr LRU %.0f clox %.0f",
+		name, 100*lruM.suboptRate(), 100*cloxM.suboptRate(),
+		100*lruM.victimReturnRate(), 100*cloxM.victimReturnRate(),
+		lruM.meanTimeToReturn(), cloxM.meanTimeToReturn())
+	if cloxHits > optHits {
+		t.Fatalf("%s: clox hits %d exceed OPT's %d — the harness itself is broken", name, cloxHits, optHits)
+	}
+}
+
+// TestReplayScanBurst: a stable hot set with periodic one-shot floods.
+// Protection should shield the hot set and approach OPT while LRU flushes it
+// on every flood.
+func TestReplayScanBurst(t *testing.T) {
+	const (
+		ops       = 60000
+		hotKeys   = 128
+		burstLen  = 512
+		burstGap  = 1000
+		burstBase = uint64(1) << 32 // one-shot ids, disjoint from the hot set
+	)
+	rng := rand.New(rand.NewSource(1))
+	var trace []uint64
+	oneShot := burstBase
+	for len(trace) < ops {
+		for range burstGap {
+			trace = append(trace, uint64(rng.Intn(hotKeys)))
+		}
+		for range burstLen {
+			trace = append(trace, oneShot)
+			oneShot++
+		}
+	}
+	trace = trace[:ops]
+
+	occ := buildOcc(trace)
+	lruHits, lruM := replayLRU(trace, replayCfg().Capacity, occ)
+	cloxHits, cloxM := replayClox(trace, replayCfg(), occ)
+	optHits := replayOPT(trace, replayCfg().Capacity)
+	logReplay(t, "scan-burst", ops, lruHits, cloxHits, optHits, lruM, cloxM)
+
+	if cloxHits <= lruHits {
+		t.Fatalf("scan-burst: clox hits %d ≤ LRU's %d — protection is not shielding the hot set", cloxHits, lruHits)
+	}
+}
+
+// TestReplayZipf: skewed stationary popularity. Protection should win
+// modestly over LRU by holding the head of the distribution.
+func TestReplayZipf(t *testing.T) {
+	const ops = 60000
+	rng := rand.New(rand.NewSource(2))
+	zipf := rand.NewZipf(rng, 1.2, 1, 2047)
+	trace := make([]uint64, ops)
+	for i := range trace {
+		trace[i] = zipf.Uint64()
+	}
+
+	occ := buildOcc(trace)
+	lruHits, lruM := replayLRU(trace, replayCfg().Capacity, occ)
+	cloxHits, cloxM := replayClox(trace, replayCfg(), occ)
+	optHits := replayOPT(trace, replayCfg().Capacity)
+	logReplay(t, "zipf", ops, lruHits, cloxHits, optHits, lruM, cloxM)
+
+	if cloxHits < lruHits {
+		t.Fatalf("zipf: clox hits %d < LRU's %d — protection should win on stationary skew", cloxHits, lruHits)
+	}
+}
+
+// TestReplaySlidingWindowDrift: the squatter detector. The working set
+// drifts across the keyspace; undecayed protection collapses here (measured
+// 50.8% hit vs LRU's 89.9% on the colibri traces) because saturated entries
+// keep their slots after the workload moves on — and those retention
+// mistakes are invisible to eviction metrics, since squatters are never
+// evicted at all. With eviction-driven decay the policy must track LRU.
+func TestReplaySlidingWindowDrift(t *testing.T) {
+	const (
+		ops        = 60000
+		windowKeys = 320 // capacity/working-set ≈ 0.8
+		slideEvery = 32  // window advances one key every N ops
+	)
+	rng := rand.New(rand.NewSource(3))
+	trace := make([]uint64, ops)
+	for i := range trace {
+		trace[i] = uint64(i/slideEvery + rng.Intn(windowKeys))
+	}
+
+	occ := buildOcc(trace)
+	lruHits, lruM := replayLRU(trace, replayCfg().Capacity, occ)
+	cloxHits, cloxM := replayClox(trace, replayCfg(), occ)
+	optHits := replayOPT(trace, replayCfg().Capacity)
+	logReplay(t, "drift", ops, lruHits, cloxHits, optHits, lruM, cloxM)
+
+	// For the record: the same trace with decay disabled shows what the
+	// assertion below is guarding against.
+	undecayedCfg := replayCfg()
+	undecayedCfg.DecayInterval = -1
+	undecayedHits, _ := replayClox(trace, undecayedCfg, occ)
+	t.Logf("drift: undecayed clox hit rate %.1f%% (squatter mode)", 100*float64(undecayedHits)/float64(ops))
+
+	if float64(cloxHits) < 0.9*float64(lruHits) {
+		t.Fatalf("drift parity broken: clox hits %d < 90%% of LRU's %d — protection is squatting (decay regression?)",
+			cloxHits, lruHits)
+	}
+}

--- a/effects/context.go
+++ b/effects/context.go
@@ -215,6 +215,7 @@ func (c *Context) TraceCtx() context.Context {
 // commands' effects are in the log but not yet in the index; this method
 // reconstructs from the log so commands within the same transaction can
 // see each other's writes.
+// The returned ReducedEffect is immutable and may be shared by later reads.
 //
 // When a txSnapshot is active (MULTI/EXEC with SSI), reads for keys not
 // yet in the context use the snapshot instead of the live index, and a
@@ -261,6 +262,10 @@ func (c *Context) GetSnapshot(key string) (*pb.ReducedEffect, []Tip, error) {
 			// so the compaction snapshot is where the set is persisted for a
 			// future bootstrapping peer to recover after the raw
 			// SubscriptionEffects have been compacted away.
+			// reconstructLocal may have returned the immutable reduced memo.
+			// Compaction owns the state it emits, so detach before stamping the
+			// subscriber set instead of forcing every read to clone up front.
+			result = cloneReduced(result)
 			result.Subscribers = c.engine.snapshotSubscribers(key)
 			snapEff := &pb.SnapshotEffect{
 				Collection: result.Collection,
@@ -751,12 +756,12 @@ func (c *Context) applySubOps(key string, ck *contextKey) {
 // effect (Key, Hlc, NodeId, ForkChoiceHash, TxnId, Deps, Kind).
 // Returns the log offset and the constructed OffsetNotify.
 func (c *Context) rawEmit(eff *pb.Effect) (Tip, *pb.OffsetNotify, error) {
-	key := string(eff.Key)
-
 	offset := c.engine.nextOffset()
 
-	slog.Debug("Emit: wrote effect",
-		"key", key, "offset", offset, "deps", eff.Deps, "tx", eff.TxnId != "")
+	if slog.Default().Enabled(c.TraceCtx(), slog.LevelDebug) {
+		slog.Debug("Emit: wrote effect",
+			"key", string(eff.Key), "offset", offset, "deps", eff.Deps, "tx", eff.TxnId != "")
+	}
 
 	// Marshal once and reuse the length for the pool's byte accounting (avoids
 	// a redundant proto.Size walk) and the bytes for the notify. The standalone
@@ -808,7 +813,9 @@ func (c *Context) Flush() error {
 
 // flushNonTx is the original Flush body for non-transactional writes.
 func (c *Context) flushNonTx() error {
-	slog.Debug("Flush: non-tx", "keys", len(c.keys))
+	if slog.Default().Enabled(c.TraceCtx(), slog.LevelDebug) {
+		slog.Debug("Flush: non-tx", "keys", len(c.keys))
+	}
 
 	for key, ck := range c.keys {
 		// Handle flush-all: wipe index before broadcasting

--- a/effects/effect.go
+++ b/effects/effect.go
@@ -761,6 +761,20 @@ func fromPbRefs(refs []*pb.EffectRef) []Tip {
 // substitution would leave us pointing at another tx-tipped offset of
 // the same in-flight txn, which is what we're trying to avoid.
 func (e *Engine) resolveTipDeps(tips []Tip) []Tip {
+	// Nearly every read is already at a committed frontier. Avoid allocating
+	// the recursive walk's closure, seen set, and output slice until at least
+	// one tip actually needs substitution.
+	needsResolution := false
+	for _, tp := range tips {
+		if _, ok := e.pendingTxTips.Load(tp); ok {
+			needsResolution = true
+			break
+		}
+	}
+	if !needsResolution {
+		return tips
+	}
+
 	seen := make(map[Tip]struct{}, len(tips))
 	var resolved []Tip
 	changed := false

--- a/effects/snapshot.go
+++ b/effects/snapshot.go
@@ -27,6 +27,7 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -86,8 +87,8 @@ type leafState struct {
 }
 
 // reducedResult is a cached materialized read keyed on the exact tip set it was
-// derived from. The result is treated as immutable: serve and store both clone,
-// so no consumer can mutate the shared copy (filterSnapshot rewrites fields).
+// derived from. The result is immutable once published. Read paths must use
+// copy-on-write before changing it (filterSnapshot and compaction do this).
 //
 // result aliases the value byte slices of the effects it was reduced from
 // (cloneData/cloneReduced share Raw slices rather than copying). Those effects
@@ -304,9 +305,10 @@ func filterSnapshot(result *pb.ReducedEffect) *pb.ReducedEffect {
 		for k, elem := range result.NetAdds {
 			if elem.ExpiresAt != nil && now.After(elem.ExpiresAt.AsTime()) {
 				if !cloned {
-					na := make(map[string]*pb.ReducedElement, len(result.NetAdds))
-					maps.Copy(na, result.NetAdds)
-					result.NetAdds = na
+					// A reduced memo may own result. Clone only on the rare
+					// expired-element path; ordinary reads remain allocation-free
+					// here and never mutate the published snapshot.
+					result = cloneReduced(result)
 					cloned = true
 				}
 				delete(result.NetAdds, k)
@@ -342,6 +344,8 @@ func filterSnapshot(result *pb.ReducedEffect) *pb.ReducedEffect {
 // read-modify-write (SETBIT, INCR, etc.) must pass the returned tips
 // to Emit so the first effect depends on the tips the snapshot was
 // actually computed from, not whatever the index contains at Emit time.
+// The returned ReducedEffect is an immutable snapshot and may be shared by
+// subsequent reads; callers that need to change it must clone it first.
 //
 // Cache hit returns immediately. On miss, walks the causal DAG from
 // the index tip set and reconstructs via ReduceBranch + canonical merge.
@@ -510,7 +514,9 @@ func (e *Engine) reconstructLocal(key string) (*pb.ReducedEffect, []Tip, int) {
 
 	// Check index for tips
 	if len(snapshotTips) == 0 {
-		slog.Debug("GetSnapshot: no tips", "key", key)
+		if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+			slog.Debug("GetSnapshot: no tips", "key", key)
+		}
 		return nil, nil, 0
 	}
 
@@ -525,19 +531,22 @@ func (e *Engine) reconstructLocal(key string) (*pb.ReducedEffect, []Tip, int) {
 	// committed answer for these exact tips, and reconstruct(key, tips) is a
 	// pure function of the tip set (the reachable DAG is immutable). Cache it in
 	// the leaf keyed on the tip set — a later write/arrival changes the tips,
-	// yielding a different key that misses. Serve and store both clone so the
-	// shared copy is never mutated (filterSnapshot rewrites fields). The memo is
+	// yielding a different key that misses. The cached result is immutable;
+	// filtering and compaction use copy-on-write before changing it. The memo is
 	// bypassed while any txn is mid-horizon: a conservative guard that keeps the
 	// cache out of the in-flight-visibility window entirely.
 	horizonClear := e.horizon == nil || e.horizon.Empty()
-	ls, _ := e.index.LoadOrStoreData(key, &leafState{})
+	ls := e.index.LoadData(key)
+	if ls == nil {
+		ls, _ = e.index.LoadOrStoreData(key, &leafState{})
+	}
 
 	var result *pb.ReducedEffect
 	var chainLen int
 	served := false
 	if horizonClear && ls != nil {
 		if rr := ls.reduced.Load(); rr != nil && tipsEqual(rr.tips, tipOffsets) {
-			result, chainLen, served = cloneReduced(rr.result), rr.chainLen, true
+			result, chainLen, served = rr.result, rr.chainLen, true
 		}
 	}
 
@@ -547,7 +556,9 @@ func (e *Engine) reconstructLocal(key string) (*pb.ReducedEffect, []Tip, int) {
 		// avoid returning a value that excludes a bind which will be present
 		// in the next reconstruct from the same tips (the Elle :incompatible-order
 		// shape from Jepsen run 26373595271).
-		slog.Debug("GetSnapshot: reconstructing", "key", key, "tips", tipOffsets)
+		if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+			slog.Debug("GetSnapshot: reconstructing", "key", key, "tips", tipOffsets)
+		}
 		var err error
 		result, chainLen, err = e.reconstruct(key, tipOffsets, "", true)
 		if err != nil {
@@ -561,7 +572,7 @@ func (e *Engine) reconstructLocal(key string) (*pb.ReducedEffect, []Tip, int) {
 			// the memo needs no refcount of its own.
 			ls.reduced.Store(&reducedResult{
 				tips:     append([]Tip(nil), tipOffsets...),
-				result:   cloneReduced(result),
+				result:   result,
 				chainLen: chainLen,
 			})
 		}
@@ -631,11 +642,18 @@ func (e *Engine) ensureSubscribedMode(key string, allowAsync bool) error {
 	if existing, ok := e.subscriptions.Load(key); ok {
 		return e.awaitSubscription(existing, unsafe)
 	}
+	// Callers on the Redis hot path may borrow key from a pooled command
+	// buffer. A new subscription outlives that command, so own the map/trie key
+	// before publishing any state. The already-subscribed path above remains
+	// allocation-free.
+	ownedKey := strings.Clone(key)
 	state := &subscriptionState{ready: make(chan struct{})}
-	if existing, loaded := e.subscriptions.LoadOrStore(key, state); loaded {
+	if existing, loaded := e.subscriptions.LoadOrStore(ownedKey, state); loaded {
 		return e.awaitSubscription(existing, unsafe)
 	}
-	slog.Debug("ensureSubscribed: bootstrapping", "key", key)
+	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		slog.Debug("ensureSubscribed: bootstrapping", "key", ownedKey)
+	}
 	succeeded := false
 	defer func() {
 		if succeeded {
@@ -645,7 +663,7 @@ func (e *Engine) ensureSubscribedMode(key string, allowAsync bool) error {
 
 	hlc := timestamppb.New(e.clock.Now())
 	eff := &pb.Effect{
-		Key:            []byte(key),
+		Key:            []byte(ownedKey),
 		Hlc:            hlc,
 		NodeId:         uint64(e.nodeID),
 		ForkChoiceHash: ComputeForkChoiceHash(e.nodeID, hlc),
@@ -657,7 +675,7 @@ func (e *Engine) ensureSubscribedMode(key string, allowAsync bool) error {
 	if err != nil {
 		// Marshal failure is a code bug; remove state so a fresh call
 		// retries from scratch and concurrent waiters re-bootstrap.
-		e.subscriptions.Delete(key)
+		e.subscriptions.Delete(ownedKey)
 		state.markFailed()
 		return err
 	}
@@ -666,7 +684,7 @@ func (e *Engine) ensureSubscribedMode(key string, allowAsync bool) error {
 	if e.effectCache != nil {
 		e.effectCache.PutSized(offset, eff, len(data))
 	}
-	e.updateIndex(key, nil, offset)
+	e.updateIndex(ownedKey, nil, offset)
 	e.fireLocalEffect(offset, eff)
 
 	if e.broadcaster == nil {
@@ -690,7 +708,7 @@ func (e *Engine) ensureSubscribedMode(key string, allowAsync bool) error {
 	// filter hasn't arrived yet forces clusterMaybeHasKey true, so a fresh
 	// node always takes the blocking bootstrap below.
 	if allowAsync &&
-		(e.inMajorityPartition() || unsafe) && !e.clusterMaybeHasKey(key) {
+		(e.inMajorityPartition() || unsafe) && !e.clusterMaybeHasKey(ownedKey) {
 		go e.broadcaster.BroadcastWithData(notify, notify.EffectData)
 		succeeded = true
 		return nil
@@ -700,8 +718,8 @@ func (e *Engine) ensureSubscribedMode(key string, allowAsync bool) error {
 	collector := &bootstrapCollector{
 		nacks: make(chan *pb.NackNotify, 64),
 	}
-	e.pendingBootstraps.Store(key, collector)
-	defer e.pendingBootstraps.Delete(key)
+	e.pendingBootstraps.Store(ownedKey, collector)
+	defer e.pendingBootstraps.Delete(ownedKey)
 
 	// Send to each peer individually and wait for ACKs. Retry if no peers
 	// responded (e.g. noise sessions not yet established after restart).
@@ -732,7 +750,7 @@ func (e *Engine) ensureSubscribedMode(key string, allowAsync bool) error {
 				// flushTx can address bind broadcast directly without
 				// re-deriving from the DAG.
 				if len(nacks) > 0 {
-					e.addPeerSubscriber(key, pid)
+					e.addPeerSubscriber(ownedKey, pid)
 				}
 				// Collect NACKs returned synchronously from ReplicateTo.
 				// HandleRemote on the peer generates these inline and
@@ -761,11 +779,11 @@ func (e *Engine) ensureSubscribedMode(key string, allowAsync bool) error {
 			select {
 			case <-bootstrapDeadline:
 				slog.Warn("subscription bootstrap: no peers responded after retries",
-					"key", key, "attempts", attempt+1)
+					"key", ownedKey, "attempts", attempt+1)
 				goto done
 			case <-time.After(500 * time.Millisecond):
 				slog.Debug("subscription bootstrap: retrying, no peers ACK'd",
-					"key", key, "attempt", attempt+1)
+					"key", ownedKey, "attempt", attempt+1)
 				continue
 			}
 		}
@@ -781,7 +799,7 @@ done:
 	// also surface ErrBootstrapIncomplete. UnsafeMode skips the gate:
 	// there is no majority to protect, only branches to merge.
 	if !unsafe && !e.broadcaster.InMajorityPartition() {
-		e.subscriptions.Delete(key)
+		e.subscriptions.Delete(ownedKey)
 		state.markFailed()
 		return ErrRegionPartitioned
 	}
@@ -805,7 +823,7 @@ done:
 					return
 				}
 				if len(nacks) > 0 {
-					e.addPeerSubscriber(key, pid)
+					e.addPeerSubscriber(ownedKey, pid)
 				}
 				mu.Lock()
 				for _, nack := range nacks {
@@ -834,18 +852,18 @@ done:
 		}
 	}
 
-	installed, skipped := e.walkAndInstall(key, unique)
+	installed, skipped := e.walkAndInstall(ownedKey, unique)
 
 	if installed > 0 {
 		if skipped > 0 {
 			slog.Debug("ensureSubscribed: bootstrap completed with partial reachability",
-				"key", key, "installed", installed, "skipped", skipped)
+				"key", ownedKey, "installed", installed, "skipped", skipped)
 		}
 		// Recover subscribers that have been compacted into snapshots. The
 		// NACK-response seeding above only learns peers that are live and
 		// authoritative right now; a peer subscribed before the last compaction
 		// (or one currently partitioned away) survives only in snapshot state.
-		e.seedSubscribersFromDag(key)
+		e.seedSubscribersFromDag(ownedKey)
 		succeeded = true
 		return nil
 	}
@@ -857,9 +875,9 @@ done:
 	// outward while incomplete. Leaves state in place (incomplete=true)
 	// so retryBootstrap can install tips and markReady when reachable.
 	slog.Debug("ensureSubscribed: incomplete bootstrap, retrying in background",
-		"key", key, "unreachable_tips", skipped)
+		"key", ownedKey, "unreachable_tips", skipped)
 	state.incomplete.Store(true)
-	go e.retryBootstrap(key, state, unique)
+	go e.retryBootstrap(ownedKey, state, unique)
 	if unsafe {
 		return nil
 	}

--- a/effects/snapshot_test.go
+++ b/effects/snapshot_test.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/puzpuzpuz/xsync/v4"
 	clox "github.com/swytchdb/swytch/cache"
@@ -139,6 +140,96 @@ func TestGetSnapshot_SingleEffect(t *testing.T) {
 	}
 	if string(r.Scalar.GetRaw()) != "hello" {
 		t.Fatalf("expected 'hello', got %q", r.Scalar.GetRaw())
+	}
+}
+
+func TestGetSnapshot_ReusesImmutableReducedMemo(t *testing.T) {
+	log := newSnapshotLog()
+	e := newSnapshotEngine(log)
+
+	off := log.putEffect(&pb.Effect{
+		Key: []byte("k"), Hlc: sTs(10), NodeId: 1,
+		Kind: &pb.Effect_Data{Data: scalarInsertRaw([]byte("hello"))},
+	})
+	e.index.Insert("k", nil, keytrie.NewTipSet(off))
+
+	first, _, _, err := e.GetSnapshot("k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, _, err := e.GetSnapshot("k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("stable reads should reuse the immutable reduced memo")
+	}
+	if string(second.GetScalar().GetRaw()) != "hello" {
+		t.Fatalf("expected hello, got %q", second.GetScalar().GetRaw())
+	}
+}
+
+func TestEnsureSubscribed_OwnsBorrowedKey(t *testing.T) {
+	e := newSnapshotEngine(nil)
+	buf := []byte("borrowed-key")
+	key := unsafe.String(unsafe.SliceData(buf), len(buf))
+
+	if err := e.ensureSubscribed(key); err != nil {
+		t.Fatal(err)
+	}
+	copy(buf, "overwritten!!")
+
+	if _, ok := e.subscriptions.Load("borrowed-key"); !ok {
+		t.Fatal("subscription retained the caller's borrowed key buffer")
+	}
+	if e.index.Contains("borrowed-key") == nil {
+		t.Fatal("index retained the caller's borrowed key buffer")
+	}
+}
+
+func TestFilterSnapshot_DoesNotMutateReducedMemo(t *testing.T) {
+	expired := &pb.ReducedElement{ExpiresAt: timestamppb.New(time.Now().Add(-time.Hour))}
+	live := &pb.ReducedElement{}
+	memo := &pb.ReducedEffect{
+		Collection: pb.CollectionKind_KEYED,
+		NetAdds: map[string]*pb.ReducedElement{
+			"expired": expired,
+			"live":    live,
+		},
+	}
+
+	filtered := filterSnapshot(memo)
+	if filtered == memo {
+		t.Fatal("expired-element filtering must detach from the immutable memo")
+	}
+	if _, ok := filtered.NetAdds["expired"]; ok {
+		t.Fatal("expired element remained in filtered result")
+	}
+	if _, ok := memo.NetAdds["expired"]; !ok {
+		t.Fatal("filtering mutated the cached reduced result")
+	}
+	if filtered.NetAdds["live"] != live {
+		t.Fatal("filtering should preserve live elements")
+	}
+}
+
+func BenchmarkGetSnapshot_Cached(b *testing.B) {
+	log := newSnapshotLog()
+	e := newSnapshotEngine(log)
+	off := log.putEffect(&pb.Effect{
+		Key: []byte("k"), Hlc: sTs(10), NodeId: 1,
+		Kind: &pb.Effect_Data{Data: scalarInsertRaw([]byte("hello"))},
+	})
+	e.index.Insert("k", nil, keytrie.NewTipSet(off))
+	if _, _, _, err := e.GetSnapshot("k"); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, _, _, err := e.GetSnapshot("k"); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/keytrie/critbit.go
+++ b/keytrie/critbit.go
@@ -97,6 +97,11 @@ type critNode[T any] struct {
 	// sweep pays one atomic load per visited leaf.
 	pins atomic.Int32      // 4 bytes,  offset 64
 	data atomic.Pointer[T] // 8 bytes,  offset 72 (leaf payload, 8-aligned)
+	// lastDecayEpoch is the eviction-decay epoch this leaf last absorbed; the
+	// sweep steps freq down by the elapsed epochs on visit (see decayLeaf).
+	// Atomic because ghost promotion resets it from the lock-free read path
+	// while the sweep writes it under evictMu.
+	lastDecayEpoch atomic.Uint64 // 8 bytes,  offset 80
 }
 
 func noop() {}
@@ -132,6 +137,9 @@ type Critbit[T any] struct {
 	// mutated only under evictMu (no atomics needed).
 	evictMu        sync.Mutex
 	evictHand      uint64
+	evictClock     uint64        // reclaims since the last decay-epoch step (under evictMu)
+	decayEvery     atomic.Uint64 // reclaims per freq-decay step (0 = auto-scale, MaxUint64 = disabled)
+	decayEpochN    atomic.Uint64 // completed decay intervals; leaves absorb the delta on sweep visit
 	evictK         atomic.Int32  // protected-freq threshold (adaptive)
 	ghostCount     atomic.Int64  // soft-deleted leaves retained for warm restart
 	windowHits     windowCounter // live accesses in the current adapt window (sharded)
@@ -444,6 +452,10 @@ func (c *Critbit[T]) allocLeafNode(key string, ts *TipSet) *critNode[T] {
 	n.tips.Store(ts)
 	n.freq.Store(1) // start warm enough to survive one sweep
 	n.lastAccess.Store(monotonic())
+	// Start the decay epoch at "now": a recycled arena slot retains the epoch
+	// of its previous occupant, and a stale epoch would make the sweep charge
+	// this leaf for decay it never lived through.
+	n.lastDecayEpoch.Store(c.decayEpoch())
 	return n
 }
 
@@ -837,9 +849,14 @@ func (c *Critbit[T]) bumpAccess(leaf *critNode[T]) {
 			// and rails k. underPressure must be the *current* over-target
 			// condition, not a "have we ever evicted" latch — a latch never falls
 			// back to false, so the rate accumulates across pauses. The predicate
-			// runs only at the f==k crossing (once per leaf lifetime), not on
-			// every read.
-			if f == c.evictK.Load() && c.underPressure != nil && c.underPressure() {
+			// runs only at the crossing (once per leaf lifetime), not on every
+			// read — except at k=0 (protection off), where every successful
+			// bump counts: the question there is "does enough recurrence exist
+			// to pay for protection at all", and once-per-residency crossings
+			// can't push the rate past rateHigh even on a hot-set workload
+			// (measured ≈0.25 on scan-burst — k never climbed and the policy
+			// stayed LRU). Resident hits per eviction can.
+			if k := c.evictK.Load(); (k == 0 || f == k) && c.underPressure != nil && c.underPressure() {
 				c.reachedProt.Add(1)
 			}
 			break

--- a/keytrie/critbit.go
+++ b/keytrie/critbit.go
@@ -791,6 +791,26 @@ func (c *Critbit[T]) Contains(key string) *TipSet {
 	return leaf.tips.Load()
 }
 
+// LoadData returns the existing leaf payload without installing one. Like
+// Contains, it is a lock-free, stale-tolerant read: compaction leaves relocated
+// husk payloads intact, so a reader that captured the old leaf still observes
+// the same *T. A successful lookup records the access for eviction policy.
+func (c *Critbit[T]) LoadData(key string) *T {
+	if c.closed.Load() {
+		return nil
+	}
+	rootNode := c.root.Load()
+	if rootNode == nil {
+		return nil
+	}
+	leaf := c.findBestMatch(rootNode, key)
+	if leaf == nil || leaf.key != key || leaf.isDeleted() {
+		return nil
+	}
+	c.bumpAccess(leaf)
+	return leaf.data.Load()
+}
+
 // bumpAccess records an access to leaf: it raises the frequency counter
 // (saturating at maxLeafFreq) and stamps lastAccess from the monotonic clock.
 // Lock-free; called on the hot read path. A ghost (freq < 0) is left alone —

--- a/keytrie/critbit_test.go
+++ b/keytrie/critbit_test.go
@@ -199,6 +199,26 @@ func TestCritbitBasicOperations(t *testing.T) {
 	}
 }
 
+func TestCritbitLoadData(t *testing.T) {
+	c := NewCritbit[int]()
+	defer c.Close()
+
+	c.Insert("key", nil, NewTipSet(r(1)))
+	if got := c.LoadData("key"); got != nil {
+		t.Fatalf("LoadData before install = %v, want nil", *got)
+	}
+	payload := 42
+	if got, loaded := c.LoadOrStoreData("key", &payload); loaded || got != &payload {
+		t.Fatalf("LoadOrStoreData = (%v, %v), want (&payload, false)", got, loaded)
+	}
+	if got := c.LoadData("key"); got != &payload {
+		t.Fatalf("LoadData = %v, want &payload", got)
+	}
+	if got := c.LoadData("missing"); got != nil {
+		t.Fatalf("LoadData missing = %v, want nil", *got)
+	}
+}
+
 func TestCritbitInsertCASFailure(t *testing.T) {
 	c := NewCritbit[struct{}]()
 	defer c.Close()

--- a/keytrie/critbit_test.go
+++ b/keytrie/critbit_test.go
@@ -201,7 +201,11 @@ func TestCritbitBasicOperations(t *testing.T) {
 
 func TestCritbitLoadData(t *testing.T) {
 	c := NewCritbit[int]()
-	defer c.Close()
+	defer func() {
+		if err := c.Close(); err != nil {
+			t.Errorf("close failed: %v", err)
+		}
+	}()
 
 	c.Insert("key", nil, NewTipSet(r(1)))
 	if got := c.LoadData("key"); got != nil {

--- a/keytrie/evict.go
+++ b/keytrie/evict.go
@@ -450,7 +450,6 @@ func (c *Critbit[T]) decayIntervalNow() uint64 {
 	switch every := c.decayEvery.Load(); every {
 	case 0:
 		return max(defaultDecayInterval, uint64(c.size.Load())/2)
-		//return defaultDecayInterval
 	case math.MaxUint64:
 		return 0
 	default:

--- a/keytrie/evict.go
+++ b/keytrie/evict.go
@@ -29,10 +29,25 @@ import (
 // as a single bounded domain (see Critbit.EvictBounded) rather than over
 // fixed-size shards, so a sweep's cost is bounded by the absolute scan budget
 // instead of a fraction of a shard.
+//
+// Boundary conditions on the policy's edge over plain LRU (measured against
+// offline Belady replay): the win lives at capacity/working-set ratios of
+// roughly 0.3–0.8 — below ~0.25 every policy produces near-identical contents,
+// above ~1 plain recency already retains the working set — and it shrinks
+// toward LRU-parity under any hot tier above the trie (subdag cache, client
+// caches), which skims the frequency skew protection feeds on. State these
+// conditions with any performance claim.
 const (
 	// defaultProtectedFreqThreshold: leaves with freq above this are
-	// protected from eviction; below-or-equal are eviction candidates.
-	defaultProtectedFreqThreshold = 2
+	// protected from eviction; below-or-equal are eviction candidates. k = 0
+	// means protection is off — every live leaf is a candidate and the sweep
+	// is pure LRU. That is the starting state: protection must earn its way
+	// in via the graduation probe (see bumpAccess) rather than being
+	// presumed, so a cache serving a low-reuse workload never starts out
+	// worse than plain LRU. On a reuse-≈1.3 real trace, starting at k=2
+	// meant every key that delivered its single re-read became a protected
+	// squatter with zero future value.
+	defaultProtectedFreqThreshold = 0
 
 	// adaptiveCheckInterval: re-evaluate k every N evictions. Kept at CloxCache's
 	// 1000: once the eviction counter was split from reclaim churn, real cold-key
@@ -65,6 +80,33 @@ const (
 	// keyspace, so eviction is O(want) and can run inline on the write path; the
 	// persistent clock hand covers the rest of the arena across successive calls.
 	minSweep = 128
+
+	// sweepSegments: the sweep window is taken as this many contiguous runs
+	// whose origins are spread evenly across the arena, not one contiguous
+	// run. Arena position correlates with insertion cohort (allocation order
+	// plus whole-chunk recycling), so a single contiguous window is
+	// age-biased sampled LRU: when the hand transits a young cohort, the
+	// "oldest in window" is itself young, and on low-reuse traces a young
+	// victim takes its only future hit with it. Measured on a reuse-≈1.3
+	// replay at the same 128-leaf budget: contiguous window −4.6pp hit rate
+	// vs true LRU (60% vs 81% of achievable re-reads); 8 spread segments
+	// recover ~97% of that gap while keeping cache locality within each run.
+	// Full 128-way striding recovers ~100% but pays a random memory access
+	// per leaf under evictMu + the reap read-lock, for ~0.1pp more.
+	sweepSegments = 8
+
+	// defaultDecayInterval: reclaims between eviction-driven frequency decay
+	// steps. Each step walks a live leaf's freq down by 1 (floor 1) as the
+	// sweep visits it, so a leaf that saturated freq while hot forgets over
+	// (maxLeafFreq-1)*interval ≈ 112 reclaims instead of squatting protected
+	// forever after the workload drifts — squatters are invisible to eviction
+	// metrics because they are never evicted at all. Linear −1 rather than
+	// halving: halving's first step (15→7) erases the hot-vs-warm ranking
+	// exactly when a starved cache needs it. The clock is reclaims, never
+	// wall time, so an idle trie forgets nothing. Too-fast decay degrades
+	// into plain LRU (never below); too-slow re-admits squatters — the knob
+	// is forgiving. Tunable via SetDecayInterval.
+	defaultDecayInterval = 8
 )
 
 // SetEvictHooks installs the consumer callbacks the eviction sweep uses.
@@ -191,6 +233,7 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 	defer c.evictMu.Unlock()
 
 	k := c.evictK.Load()
+	epoch := c.decayEpoch()
 	// Window: wide enough to choose the want oldest cold leaves with some
 	// selectivity (so recent writes are spared), but bounded to a small multiple
 	// of want rather than a fraction of the whole keyspace. The persistent clock
@@ -206,10 +249,9 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 	}
 	cands := make([]cand, 0, window)
 	var (
-		oldestGhost *critNode[T]
-		ghostAccess = uint64(math.MaxUint64)
-		fbVictim    *critNode[T]
-		fbAccess    = uint64(math.MaxUint64)
+		ghosts   []cand // ghosts seen this sweep, sorted oldest-first below
+		fbVictim *critNode[T]
+		fbAccess = uint64(math.MaxUint64)
 	)
 
 	// Hold the reap read-lock across the sweep and the claims. It excludes the
@@ -222,10 +264,16 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 		access := leaf.lastAccess.Load()
 		if leaf.deleted.Load() {
 			// The sweep only forwards deleted leaves that are ghosts (freq < 0).
-			if access < ghostAccess {
-				oldestGhost, ghostAccess = leaf, access
-			}
+			ghosts = append(ghosts, cand{leaf, access})
 			return
+		}
+		// Absorb pending eviction-driven decay before judging protection: −1
+		// per elapsed epoch, floor 1, so a leaf that saturated freq while hot
+		// steps back below k after the workload drifts instead of squatting on
+		// its slot forever. Ghosts are exempt (their forgetting is turnover);
+		// pinned leaves still decay so freq stays honest if they unpin.
+		if epoch > 0 {
+			decayLeaf(leaf, epoch)
 		}
 		if leaf.pinned {
 			return // pinned (e.g. a system key) — verdict cached at leaf creation
@@ -236,7 +284,13 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 		if access < fbAccess {
 			fbVictim, fbAccess = leaf, access
 		}
-		if leaf.freq.Load() <= k {
+		// k == 0 is explicit "protection off": every live leaf is a candidate
+		// and the batch is pure LRU. Without the special case, freq <= 0
+		// matches nobody and eviction would fall through to the single-victim
+		// fallback — LRU selection, but one reclaim per sweep instead of
+		// `want`, and no ghosting (which is the recurrence memory k needs to
+		// climb back out of 0).
+		if k == 0 || leaf.freq.Load() <= k {
 			cands = append(cands, cand{leaf, access})
 		}
 	})
@@ -246,6 +300,32 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 	if len(cands) > want {
 		sort.Slice(cands, func(i, j int) bool { return cands[i].access < cands[j].access })
 		cands = cands[:want]
+	}
+	// Oldest-first, so the trim below and the reclaim fallback always take the
+	// least-recent ghost.
+	sort.Slice(ghosts, func(i, j int) bool { return ghosts[i].access < ghosts[j].access })
+
+	// tick advances the decay clock one reclaim: forgetting is
+	// eviction-clocked, never wall-clocked, so an idle trie forgets nothing.
+	tick := func() {
+		c.evictClock++
+		if every := c.decayIntervalNow(); every > 0 && c.evictClock >= every {
+			c.evictClock = 0
+			c.decayEpochN.Add(1)
+		}
+	}
+
+	// trimOldestGhost reclaims the least-recent ghost seen this sweep, skipping
+	// any that were concurrently promoted back to live.
+	trimOldestGhost := func() bool {
+		for len(ghosts) > 0 {
+			g := ghosts[0].leaf
+			ghosts = ghosts[1:]
+			if c.reclaimGhost(g) {
+				return true
+			}
+		}
+		return false
 	}
 
 	type evicted struct {
@@ -264,6 +344,18 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 		leaf.tips.Store(nil)
 		leaf.data.Store(nil)
 		c.size.Add(-1)
+		// At ghost capacity, trim the oldest existing ghost to make room BEFORE
+		// ghosting the fresh victim. The order is load-bearing: the victim was
+		// chosen as LRU, so its recency is near-oldest — ghost-first followed by
+		// "trim the LRU ghost" would almost always trim the ghost just created.
+		// Ghost memory then freezes on a stale early cohort and every returning
+		// key re-admits at freq 1 like a stranger; nothing crashes, the policy
+		// just quietly becomes LRU-with-overhead (the colibri C port inverted
+		// this exact order). Fresh ghosts from earlier victims in this batch are
+		// not in the ghosts slice, so they can never be the trimmed one.
+		if c.ghostCount.Load() >= c.ghostCap() {
+			trimOldestGhost()
+		}
 		if c.ghostCount.Load() < c.ghostCap() {
 			// Ghost: retain the frequency (negated) for a warm restart.
 			for {
@@ -281,6 +373,7 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 			c.deletedCount.Add(1)
 			c.enqueueReap(leaf)
 		}
+		tick()
 		victims = append(victims, evicted{leaf.key, tips, data})
 	}
 
@@ -288,13 +381,13 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 	// of evicting a hot key; only with neither do we take the LRU protected leaf.
 	reclaimedGhost := false
 	if len(victims) == 0 {
-		if oldestGhost != nil {
-			c.reclaimGhost(oldestGhost)
+		if trimOldestGhost() {
 			reclaimedGhost = true
 			// Count the reclaim as an unprotected eviction (a ghost is a
 			// previously-cold key) so the adaptive-k clock keeps advancing — without
 			// this, k freezes exactly when ghost reclaims dominate (cold-scarce).
 			c.evictedUnprot.Add(1)
+			tick()
 		} else if fbVictim != nil && c.claimForEviction(fbVictim) {
 			tips := fbVictim.tips.Load()
 			data := fbVictim.data.Load()
@@ -305,6 +398,7 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 			c.enqueueReap(fbVictim)
 			victims = append(victims, evicted{fbVictim.key, tips, data})
 			c.evictedProt.Add(1)
+			tick()
 		}
 	} else {
 		c.evictedUnprot.Add(uint64(len(victims)))
@@ -331,6 +425,68 @@ func (c *Critbit[T]) EvictBatch(want int) int {
 		return 1
 	}
 	return len(victims)
+}
+
+// SetDecayInterval overrides the eviction-driven frequency decay cadence:
+// n > 0 sets reclaims-per-step, n <= 0 disables decay entirely. Call at setup;
+// the default auto-scales with the live-leaf count (see decayIntervalNow).
+func (c *Critbit[T]) SetDecayInterval(n int) {
+	if n > 0 {
+		c.decayEvery.Store(uint64(n))
+		return
+	}
+	// MaxUint64 keeps the epoch counter frozen — decay never applies — while
+	// staying distinct from 0, which means "not configured, auto-scale".
+	c.decayEvery.Store(math.MaxUint64)
+}
+
+// decayIntervalNow returns the reclaims-per-decay-step in effect: the
+// configured value when set, otherwise auto-scaled to the current live-leaf
+// count so forget-from-saturation stays ≈7 turnovers of the resident set
+// regardless of domain size — with a fixed small interval, a large domain's
+// epochs elapse so fast that every leaf hits the floor by its next sweep
+// visit and protection degrades to plain LRU. Returns 0 when disabled.
+func (c *Critbit[T]) decayIntervalNow() uint64 {
+	switch every := c.decayEvery.Load(); every {
+	case 0:
+		return max(defaultDecayInterval, uint64(c.size.Load())/2)
+		//return defaultDecayInterval
+	case math.MaxUint64:
+		return 0
+	default:
+		return every
+	}
+}
+
+// decayEpoch returns the current eviction-decay epoch. Leaves store the epoch
+// they last absorbed and step down by the difference when the sweep visits
+// them. The explicit counter (rather than clock/interval division) keeps
+// epochs monotonic while the auto-scaled interval moves with the live count.
+func (c *Critbit[T]) decayEpoch() uint64 {
+	return c.decayEpochN.Load()
+}
+
+// decayLeaf absorbs a leaf's pending eviction-driven frequency decay: one −1
+// step per decay epoch elapsed since its last sweep visit, floor 1. The CAS on
+// lastDecayEpoch elects a single decayer per epoch — the sweep runs under
+// evictMu, but ghost promotion also writes the field from the lock-free read
+// path; the freq CAS loop rides out concurrent bumpAccess bumps.
+func decayLeaf[T any](leaf *critNode[T], epoch uint64) {
+	last := leaf.lastDecayEpoch.Load()
+	if last >= epoch || !leaf.lastDecayEpoch.CompareAndSwap(last, epoch) {
+		return
+	}
+	steps := epoch - last
+	for {
+		f := leaf.freq.Load()
+		if f <= 1 {
+			return // floor 1; ghosts (freq < 0) never reach here
+		}
+		nf := f - int32(min(steps, uint64(f-1)))
+		if leaf.freq.CompareAndSwap(f, nf) {
+			return
+		}
+	}
 }
 
 // claimForEviction atomically claims a live leaf as an eviction victim and
@@ -395,6 +551,11 @@ func (c *Critbit[T]) promoteIfGhost(leaf *critNode[T]) {
 		nf := min(-f+1, maxLeafFreq)
 		if leaf.freq.CompareAndSwap(f, nf) {
 			c.ghostCount.Add(-1)
+			// The ghost period is not decay debt: without this reset the next
+			// sweep visit would charge every epoch spent as a ghost against the
+			// remembered freq and collapse it to the floor, erasing the warm
+			// restart the ghost exists to provide.
+			leaf.lastDecayEpoch.Store(c.decayEpoch())
 			// A returning ghost is a window miss (op, not hit). Shard by the
 			// reactivated leaf's address, same as the live-hit path.
 			c.windowOps.add(unsafe.Pointer(leaf), 1)
@@ -426,6 +587,21 @@ func (c *Critbit[T]) maybeAdaptK() {
 	// Don't reintroduce that store. The underflow is also simply cheaper than
 	// tracking the burst with an explicit loop.
 	if total-c.lastAdaptCheck.Load() < adaptiveCheckInterval {
+		return
+	}
+	// Window gate (ported from the colibri C fix): the eviction interval arms
+	// the check, but the k step waits for a completed hit-rate window, making
+	// adaptation strictly change → measure → learn — every k step is evaluated
+	// over exactly one full window, and lastKDir is never overwritten by an
+	// unmeasured call. Without the gate, several k steps land inside one
+	// window whenever evictions outpace probes (exactly when the cache is
+	// under pressure and adaptation matters) and the gradient learns a
+	// hit-rate delta attributed to only the most recent direction — noise.
+	// lastAdaptCheck is not advanced while gated, so the check stays armed
+	// until the window completes; this also paces the post-halving underflow
+	// burst above to one k step per completed window rather than one per
+	// eviction, which is the burst's intended shape.
+	if c.windowOps.load() < hitRateWindowSize {
 		return
 	}
 	c.lastAdaptCheck.Store(total)
@@ -484,7 +660,13 @@ func (c *Critbit[T]) maybeAdaptK() {
 	rateHigh := float64(c.rateHigh.Load()) / 10000.0
 	k := c.evictK.Load()
 	var dir int32
-	if rate < rateLow && k > 1 {
+	// k may walk all the way to 0: protection off, pure LRU. When graduation
+	// collapses, LRU IS the correct policy and the adapter must be able to
+	// reach it — a floor of 1 still shields every key that was ever read
+	// once, which on low-reuse workloads is exactly the spent-key set.
+	// The graduation probe keeps counting at k=0 (see bumpAccess), so a
+	// workload that develops skew climbs back out.
+	if rate < rateLow && k > 0 {
 		c.evictK.Store(k - 1)
 		dir = -1
 	} else if rate > rateHigh && k < maxLeafFreq-1 {
@@ -526,30 +708,57 @@ func (c *Critbit[T]) sweepLeaves(base int, fn func(*critNode[T])) {
 		base = 1
 	}
 
-	hand := c.evictHand
-	live := 0
-	var i uint64
-	for ; live < base && i < total; i++ {
-		idx := (hand + i) % total
-		chunk := chunks[idx/chunkSize]
-		if chunk == nil {
-			// Chunk was reclaimed and not recycled. Jump the hand to the next
-			// chunk boundary in one step — paying one iteration per dead slot
-			// made the sweep O(high-water mark) on a churned arena, and the
-			// sweep runs under the reap read-lock with evictMu held, so every
-			// wasted iteration is serialized against writers.
-			i += chunkSize - 1 - idx%chunkSize
-			continue
-		}
-		n := &chunk[idx%chunkSize]
-		if n.deleted.Load() {
-			if n.freq.Load() < 0 {
-				fn(n) // ghost — forwarded for the reclaim fallback, not counted
-			}
-			continue // ghosts/uninitialized/unlink-pending don't count as live
-		}
-		fn(n)
-		live++
+	// Segment the window across the arena (see sweepSegments). When the whole
+	// live set fits in the window there is nothing to de-bias — a single
+	// contiguous pass keeps full deterministic coverage for small tries.
+	nSeg := sweepSegments
+	if int64(base) >= c.size.Load() || base < nSeg {
+		nSeg = 1
 	}
-	c.evictHand = hand + i
+	segLen := base / nSeg
+	segGap := total / uint64(nSeg) // origin spacing; also each segment's max span
+	if segGap == 0 {
+		segGap = total
+	}
+
+	hand := c.evictHand
+	var advance uint64
+	for s := 0; s < nSeg; s++ {
+		want := segLen
+		if s == nSeg-1 {
+			want = base - segLen*(nSeg-1) // remainder rides the last segment
+		}
+		origin := hand + uint64(s)*segGap
+		live := 0
+		var j uint64
+		for ; live < want && j < segGap; j++ {
+			idx := (origin + j) % total
+			chunk := chunks[idx/chunkSize]
+			if chunk == nil {
+				// Chunk was reclaimed and not recycled. Jump to the next
+				// chunk boundary in one step — paying one iteration per dead
+				// slot made the sweep O(high-water mark) on a churned arena,
+				// and the sweep runs under the reap read-lock with evictMu
+				// held, so every wasted iteration is serialized against
+				// writers.
+				j += chunkSize - 1 - idx%chunkSize
+				continue
+			}
+			n := &chunk[idx%chunkSize]
+			if n.deleted.Load() {
+				if n.freq.Load() < 0 {
+					fn(n) // ghost — forwarded for the reclaim fallback, not counted
+				}
+				continue // ghosts/uninitialized/unlink-pending don't count as live
+			}
+			fn(n)
+			live++
+		}
+		if s == 0 {
+			// The hand advances by segment 0's span only; every origin rotates
+			// with it, so successive sweeps still cover the entire arena.
+			advance = max(j, 1)
+		}
+	}
+	c.evictHand = hand + advance
 }

--- a/keytrie/evict_test.go
+++ b/keytrie/evict_test.go
@@ -20,7 +20,9 @@
 package keytrie
 
 import (
+	"container/list"
 	"fmt"
+	"math/rand"
 	"runtime"
 	"testing"
 )
@@ -165,6 +167,8 @@ func TestEvictBatch_SkipsDynamicallyPinned(t *testing.T) {
 func TestEvictBounded_ReclaimsGhostBeforeHotKey(t *testing.T) {
 	c := NewCritbit[struct{}]()
 	c.SetEvictHooks(func(string) bool { return true }, func(string, []EffectRef, *struct{}) {}, func() bool { return true })
+	// The scenario needs a protected class; the default k=0 is pure LRU.
+	c.evictK.Store(2)
 
 	all := []string{"cold-1", "cold-2", "hot-1", "hot-2"}
 	for _, k := range all {
@@ -356,5 +360,178 @@ func TestGraduationGatedByPressure(t *testing.T) {
 	}
 	if got := c.EvictStats().ReachedProtected; got == 0 {
 		t.Fatal("ReachedProtected = 0 with underPressure=true; want the crossing counted")
+	}
+}
+
+// findLeaf scans the leaf arena for a leaf carrying key, ghosts included
+// (Contains hides deleted leaves). Test-only; not concurrency-safe.
+func findLeaf[T any](c *Critbit[T], key string) *critNode[T] {
+	for _, chunk := range c.leafArena.list.Load().chunks {
+		for i := range chunk {
+			if n := &chunk[i]; n.key == key {
+				return n
+			}
+		}
+	}
+	return nil
+}
+
+// TestEvictBatch_GhostTrimOrder pins the ghost-trim order: at ghost capacity,
+// the oldest EXISTING ghost is trimmed to make room before the fresh victim is
+// ghosted. The inverted order (ghost first, then trim the LRU ghost) is
+// refactor-bait that survives review: the victim was chosen as LRU, so its
+// recency is near-oldest, and the just-created ghost is almost always the one
+// trimmed — ghost memory freezes on a stale cohort, every returning key
+// re-admits at freq 1, and the policy quietly becomes LRU-with-overhead.
+func TestEvictBatch_GhostTrimOrder(t *testing.T) {
+	c := NewCritbit[struct{}]()
+	c.SetEvictHooks(func(string) bool { return true }, func(string, []EffectRef, *struct{}) {}, func() bool { return true })
+
+	// The victim-to-be goes in first, so its lastAccess predates every ghost's.
+	// Pin it so the fodder churn below can't take it early.
+	c.Insert("victim", nil, NewTipSet(tip(1)))
+	if !c.Pin("victim") {
+		t.Fatal("Pin on a live key must succeed")
+	}
+
+	// Fill the ghost cache to capacity with fodder evictions.
+	ghostCap := int(c.ghostCap())
+	for i := range ghostCap {
+		c.Insert(fmt.Sprintf("fodder-%04d", i), nil, NewTipSet(tip(uint64(i+2))))
+	}
+	for range ghostCap {
+		if !c.EvictBounded(64) {
+			t.Fatal("fodder eviction failed")
+		}
+	}
+	if got := c.ghostCount.Load(); got != int64(ghostCap) {
+		t.Fatalf("ghostCount = %d; want %d (at capacity)", got, ghostCap)
+	}
+
+	// Unpin and evict once: the victim is the LRU cold leaf and its recency is
+	// older than all existing ghosts — the doc scenario where the buggy order
+	// trims the fresh ghost.
+	if !c.Unpin("victim") {
+		t.Fatal("Unpin on a live key must succeed")
+	}
+	if !c.EvictBounded(64) {
+		t.Fatal("expected the victim to be evicted")
+	}
+
+	if got := c.ghostCount.Load(); got != int64(ghostCap) {
+		t.Fatalf("ghostCount = %d after trim+ghost; want %d (net unchanged)", got, ghostCap)
+	}
+	if n := findLeaf(c, "victim"); n == nil || n.freq.Load() >= 0 {
+		t.Fatal("fresh victim must survive as a ghost")
+	}
+	if n := findLeaf(c, "fodder-0000"); n != nil && n.freq.Load() < 0 {
+		t.Fatal("oldest existing ghost must be the one trimmed")
+	}
+	if n := findLeaf(c, "fodder-0001"); n == nil || n.freq.Load() >= 0 {
+		t.Fatal("younger ghosts must survive the trim")
+	}
+}
+
+// TestDecayStepsLeafFreqDown verifies eviction-driven frequency decay: a leaf
+// that saturated freq while hot steps down by 1 per elapsed decay epoch as the
+// sweep visits it, and an idle policy (no reclaims) decays nothing.
+func TestDecayStepsLeafFreqDown(t *testing.T) {
+	c := NewCritbit[struct{}]()
+	c.SetDecayInterval(100)
+	c.SetEvictHooks(func(string) bool { return true }, func(string, []EffectRef, *struct{}) {}, func() bool { return true })
+	// Pin a protected class so the hot leaf is never a victim; the default
+	// k=0 (pure LRU) would evict it as the oldest leaf during the churn.
+	c.evictK.Store(2)
+
+	c.Insert("hot", nil, NewTipSet(tip(1)))
+	for range 30 {
+		c.LoadData("hot") // Contains doesn't record accesses; LoadData does
+	}
+	if got := findLeaf(c, "hot").freq.Load(); got != maxLeafFreq {
+		t.Fatalf("hot freq = %d after saturation; want %d", got, maxLeafFreq)
+	}
+
+	// 150 reclaims cross one decay interval (100) exactly once: the hot leaf —
+	// protected, never a victim — must step 15 → 14, no further.
+	for i := range 150 {
+		c.Insert(fmt.Sprintf("fodder-%04d", i), nil, NewTipSet(tip(uint64(i+2))))
+		if !c.EvictBounded(64) {
+			t.Fatalf("eviction %d failed", i)
+		}
+	}
+	if got := findLeaf(c, "hot").freq.Load(); got != maxLeafFreq-1 {
+		t.Fatalf("hot freq = %d after one decay epoch; want %d", got, maxLeafFreq-1)
+	}
+}
+
+// TestSlidingWindowDriftParity is the squatter detector: a working set that
+// drifts across the keyspace. Undecayed protection collapses here (measured
+// 50.8%% hit vs plain LRU's 89.9%% on the colibri traces) because saturated
+// leaves keep their slots after the workload moves on; with eviction-driven
+// decay the policy must track LRU. Retention mistakes are invisible to
+// eviction metrics — squatters are never evicted — so hit-rate parity against
+// an LRU replay of the same trace is the only signal that catches this.
+func TestSlidingWindowDriftParity(t *testing.T) {
+	const (
+		capacity   = 128
+		windowKeys = 160 // capacity/working-set ≈ 0.8: the band where policy differences show
+		ops        = 60000
+		slideEvery = 40 // window advances one key every N ops
+	)
+	rng := rand.New(rand.NewSource(42))
+	trace := make([]int, ops)
+	for i := range trace {
+		trace[i] = i/slideEvery + rng.Intn(windowKeys)
+	}
+	key := func(id int) string { return fmt.Sprintf("key-%06d", id) }
+
+	// Plain-LRU baseline over the identical trace.
+	lru := list.New()
+	inLRU := make(map[int]*list.Element, capacity)
+	lruHits := 0
+	for _, id := range trace {
+		if el, ok := inLRU[id]; ok {
+			lruHits++
+			lru.MoveToFront(el)
+			continue
+		}
+		if lru.Len() >= capacity {
+			back := lru.Back()
+			delete(inLRU, back.Value.(int))
+			lru.Remove(back)
+		}
+		inLRU[id] = lru.PushFront(id)
+	}
+
+	c := NewCritbit[struct{}]()
+	c.SetEvictHooks(
+		func(string) bool { return true },
+		func(string, []EffectRef, *struct{}) {},
+		func() bool { return c.Size() >= capacity },
+	)
+	payload := struct{}{}
+	trieHits := 0
+	for _, id := range trace {
+		// LoadData is the probe that records the access for the policy
+		// (Contains doesn't); the payload install below makes a resident key
+		// distinguishable from a miss.
+		if c.LoadData(key(id)) != nil {
+			trieHits++
+			continue
+		}
+		c.Insert(key(id), nil, NewTipSet(tip(uint64(id))))
+		c.LoadOrStoreData(key(id), &payload)
+		for c.Size() > capacity {
+			if c.EvictBatch(int(c.Size())-capacity) == 0 {
+				break
+			}
+		}
+	}
+
+	t.Logf("sliding-window drift: LRU hits %d (%.1f%%), trie hits %d (%.1f%%)",
+		lruHits, 100*float64(lruHits)/ops, trieHits, 100*float64(trieHits)/ops)
+	if float64(trieHits) < 0.9*float64(lruHits) {
+		t.Fatalf("drift parity broken: trie hits %d < 90%% of LRU's %d — protection is squatting (decay regression?)",
+			trieHits, lruHits)
 	}
 }

--- a/redis/shared/command.go
+++ b/redis/shared/command.go
@@ -331,7 +331,7 @@ func (c *Command) Reset() {
 			PutDataBuf(arg)
 		}
 	}
-	clear(c.Args)
+	clear(c.Args[:cap(c.Args)])
 	if c.RawName != nil {
 		PutDataBuf(c.RawName)
 	}

--- a/redis/shared/command.go
+++ b/redis/shared/command.go
@@ -19,7 +19,11 @@
 
 package shared
 
-import "github.com/swytchdb/swytch/effects"
+import (
+	"unsafe"
+
+	"github.com/swytchdb/swytch/effects"
+)
 
 // CommandType represents the type of Redis command
 type CommandType int
@@ -316,6 +320,7 @@ type Command struct {
 	Transaction any
 	Context     *effects.Context
 	Runtime     *effects.Engine
+	keyScratch  [1]string
 }
 
 // Reset clears the command for reuse, preserving slice capacity
@@ -326,12 +331,33 @@ func (c *Command) Reset() {
 			PutDataBuf(arg)
 		}
 	}
+	clear(c.Args)
 	if c.RawName != nil {
 		PutDataBuf(c.RawName)
 	}
 	// Zero all fields while preserving Args capacity
 	args := c.Args[:0]
 	*c = Command{Args: args}
+}
+
+// SetSingleKey records arg as this command's one-key scratch value without
+// copying the pooled parser bytes. The returned string and SingleKeySlice are
+// valid only until the command is reset or returned to the pool. Code that
+// retains a key beyond command execution must clone it first.
+func (c *Command) SetSingleKey(arg []byte) string {
+	key := unsafe.String(unsafe.SliceData(arg), len(arg))
+	c.keyScratch[0] = key
+	return key
+}
+
+// SingleKeyValue returns the value installed by SetSingleKey.
+func (c *Command) SingleKeyValue() string {
+	return c.keyScratch[0]
+}
+
+// SingleKeySlice returns allocation-free one-key scratch storage.
+func (c *Command) SingleKeySlice() []string {
+	return c.keyScratch[:]
 }
 
 // LookupCommandName returns the CommandType for a given uppercase command name.

--- a/redis/shared/pools.go
+++ b/redis/shared/pools.go
@@ -144,7 +144,7 @@ func PutCommand(cmd *Command) {
 			PutDataBuf(arg)
 		}
 	}
-	clear(cmd.Args)
+	clear(cmd.Args[:cap(cmd.Args)])
 	cmd.keyScratch[0] = ""
 	cmd.Args = cmd.Args[:0]
 	commandPool.Put(cmd)

--- a/redis/shared/pools.go
+++ b/redis/shared/pools.go
@@ -144,6 +144,8 @@ func PutCommand(cmd *Command) {
 			PutDataBuf(arg)
 		}
 	}
+	clear(cmd.Args)
+	cmd.keyScratch[0] = ""
 	cmd.Args = cmd.Args[:0]
 	commandPool.Put(cmd)
 }

--- a/redis/shared/protocol.go
+++ b/redis/shared/protocol.go
@@ -161,13 +161,19 @@ func (p *Parser) readArrayCommand(cmd *Command) (*Command, error) {
 
 	// Parse command type from first argument
 	if len(cmd.Args) > 0 {
-		cmd.Type = ParseCommandType(cmd.Args[0])
+		name := cmd.Args[0]
+		cmd.Type = ParseCommandType(name)
 		// Store raw name for unknown commands (useful for logging)
 		if cmd.Type == CmdUnknown {
-			cmd.RawName = cmd.Args[0]
+			cmd.RawName = name
+		} else {
+			PutDataBuf(name)
 		}
-		// Remove command name from Args, leaving only actual arguments
-		cmd.Args = cmd.Args[1:]
+		// Remove the command name without advancing the slice base. Advancing it
+		// loses one slot of pooled capacity per command and eventually forces a
+		// new Args backing array on the hot parser path.
+		copy(cmd.Args, cmd.Args[1:])
+		cmd.Args = cmd.Args[:len(cmd.Args)-1]
 	}
 
 	return cmd, nil
@@ -212,12 +218,16 @@ func (p *Parser) readInlineCommand(cmd *Command) (*Command, error) {
 	}
 
 	// Parse command type from first token
-	cmd.Type = ParseCommandType(cmd.Args[0])
+	name := cmd.Args[0]
+	cmd.Type = ParseCommandType(name)
 	// Store raw name for unknown commands (useful for logging)
 	if cmd.Type == CmdUnknown {
-		cmd.RawName = cmd.Args[0]
+		cmd.RawName = name
+	} else {
+		PutDataBuf(name)
 	}
-	cmd.Args = cmd.Args[1:]
+	copy(cmd.Args, cmd.Args[1:])
+	cmd.Args = cmd.Args[:len(cmd.Args)-1]
 
 	return cmd, nil
 }

--- a/redis/shared/protocol.go
+++ b/redis/shared/protocol.go
@@ -172,8 +172,10 @@ func (p *Parser) readArrayCommand(cmd *Command) (*Command, error) {
 		// Remove the command name without advancing the slice base. Advancing it
 		// loses one slot of pooled capacity per command and eventually forces a
 		// new Args backing array on the hot parser path.
+		last := len(cmd.Args) - 1
 		copy(cmd.Args, cmd.Args[1:])
-		cmd.Args = cmd.Args[:len(cmd.Args)-1]
+		cmd.Args[last] = nil
+		cmd.Args = cmd.Args[:last]
 	}
 
 	return cmd, nil
@@ -226,8 +228,10 @@ func (p *Parser) readInlineCommand(cmd *Command) (*Command, error) {
 	} else {
 		PutDataBuf(name)
 	}
+	last := len(cmd.Args) - 1
 	copy(cmd.Args, cmd.Args[1:])
-	cmd.Args = cmd.Args[:len(cmd.Args)-1]
+	cmd.Args[last] = nil
+	cmd.Args = cmd.Args[:last]
 
 	return cmd, nil
 }

--- a/redis/shared/registry.go
+++ b/redis/shared/registry.go
@@ -142,7 +142,8 @@ func KeysFirst(cmd *Command) []string {
 	if len(cmd.Args) < 1 {
 		return nil
 	}
-	return []string{string(cmd.Args[0])}
+	cmd.SetSingleKey(cmd.Args[0])
+	return cmd.SingleKeySlice()
 }
 
 // KeysAfterStreams extracts keys after the STREAMS keyword.

--- a/redis/str/strings.go
+++ b/redis/str/strings.go
@@ -200,12 +200,12 @@ func handleGet(cmd *shared.Command, w *shared.Writer, db *shared.Database) (vali
 		return
 	}
 
-	key := string(cmd.Args[0])
-	keys = []string{key}
+	cmd.SetSingleKey(cmd.Args[0])
+	keys = cmd.SingleKeySlice()
 	valid = true
 
 	runner = func() {
-		snap, _, exists, wrongType, err := getStringSnapshot(cmd, key)
+		snap, _, exists, wrongType, err := getStringSnapshot(cmd, cmd.SingleKeyValue())
 		if err != nil {
 			w.WriteError(err.Error())
 			return


### PR DESCRIPTION
## Two things

Under load, there were two allocation sites accounting for 70% of the GC's work. The first commit addresses this directly.

The second commit was learnings from applying cloxcache to https://github.com/JustVugg/colibri/pull/223.

Under specific, antagonistic traces (write heavy, almost no reuse), cloxcache will want to protect everything, but cannot achieve k=0, thereby causing a failure if a scan burst occurs.

The second commit allows two things:
1. For cloxcache to fallback to pure LRU when it detects that as the best policy to apply (no detected frequency signal to exploit).
2. For the keytrie port, to properly "randomly" scan memory for eviction candidates instead of sequentially; which in the case of keytrie, memory is sequentially appended, so it would eventually get to a point where every eviction would just evict the newest thing.

<img width="692" height="158" alt="image" src="https://github.com/user-attachments/assets/ec4dba46-e42c-4064-87ff-9d42cd4c1cf8" />

As you can see, the scan burst still hurts worse than LRU in the near end of the trace, but it at least recovers from it correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable, eviction-driven frequency decay for cache entries, including options to enable, disable, or automatically tune decay.
  * Added a cache data lookup capability without creating missing entries.
  * Improved default cache behavior to begin with LRU-style protection.

* **Bug Fixes**
  * Improved ghost-entry cleanup and eviction ordering.
  * Preserved snapshot consistency when filtering or reusing cached results.
  * Ensured subscription keys remain stable during asynchronous operations.

* **Performance**
  * Reduced unnecessary allocations in effect resolution, snapshot retrieval, logging, and Redis command processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->