### PR TITLE
allow a node to fix corruption

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -69,6 +69,14 @@ type Beacon struct {
 	removeMu     sync.Mutex
 	removeSignal chan struct{}
 
+	// membershipWriteMu serializes the startup frontier repair against
+	// applyQueuedRemovals — the only other membership writer alive during
+	// bootstrap. A removal emit racing the repair mint would land as a sibling
+	// branch bypassing the repair snapshot, and a frontier with such a branch
+	// re-exposes the unreachable ancestry to every reader (the walk only stops
+	// at a snapshot that is the sole convergence point).
+	membershipWriteMu sync.Mutex
+
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -135,6 +143,8 @@ func (b *Beacon) applyQueuedRemovals() {
 	if len(batch) == 0 {
 		return
 	}
+	b.membershipWriteMu.Lock()
+	defer b.membershipWriteMu.Unlock()
 
 	// The cloud re-offers every pending removal on each presence sweep until
 	// its TTL expires — it is zero-knowledge, so it cannot see the roster and

--- a/beacon/bootstrap.go
+++ b/beacon/bootstrap.go
@@ -94,6 +94,19 @@ func (b *Beacon) bootstrap(ctx context.Context) error {
 func (b *Beacon) cloudCandidates(ctx context.Context) []string {
 	reduced, err := b.discoverMembersWithRetry(ctx)
 	if err != nil {
+		if errors.Is(err, cluster.ErrCDNBlobMissing) {
+			// The roster frontier references ancestry whose CDN blobs are
+			// gone — a durable hole, not an outage. Retrying can't heal it
+			// and every node in the fleet is equally stuck against it, so
+			// supersede the frontier and start solo; peers pick up the
+			// repaired roster on their next boot. Nodes restarting in the
+			// same instant can each mint a repair, leaving sibling snapshots
+			// that keep the key unreadable — accepted: the next
+			// non-simultaneous restart repairs over them, since the walk
+			// fails with the same ErrCDNBlobMissing beneath the siblings.
+			b.repairMembershipFrontier(ctx, err)
+			return nil
+		}
 		slog.Warn("beacon: cloud member discovery failed after retries, starting solo", "error", err)
 		return nil
 	}
@@ -107,6 +120,24 @@ func (b *Beacon) cloudCandidates(ctx context.Context) []string {
 		addrs = append(addrs, m.Addr)
 	}
 	return addrs
+}
+
+// repairMembershipFrontier is the one-shot startup repair for a cloud
+// membership frontier whose ancestry is provably holed. Held under
+// membershipWriteMu so a cloud-pushed removal burst can't emit a sibling
+// branch while the repair snapshot is being minted.
+func (b *Beacon) repairMembershipFrontier(ctx context.Context, cause error) {
+	slog.Warn("beacon: cloud membership frontier is unreadable, repairing with a superseding snapshot",
+		"error", cause)
+	b.membershipWriteMu.Lock()
+	defer b.membershipWriteMu.Unlock()
+	superseded, err := b.cfg.Cloud.RepairFrontier(ctx, MembershipKey)
+	if err != nil {
+		slog.Error("beacon: membership frontier repair failed, starting solo unrepaired", "error", err)
+		return
+	}
+	slog.Warn("beacon: cloud membership frontier repaired, starting solo",
+		"superseded_tips", superseded)
 }
 
 // discoverMembersWithRetry reads the cloud membership roster, retrying on

--- a/cluster/cloud_sync.go
+++ b/cluster/cloud_sync.go
@@ -54,6 +54,12 @@ const (
 // cloudEffectInfo is the domain-separation info for sealed effect payloads.
 var cloudEffectInfo = []byte("effect")
 
+// ErrCDNBlobMissing marks a CDN fetch that answered 404: the blob is provably
+// absent from cloud storage, as opposed to the cloud being unreachable. A
+// frontier walk failing with this is a durable hole — retrying cannot heal it,
+// only RepairFrontier can.
+var ErrCDNBlobMissing = errors.New("cdn blob missing")
+
 // Version is the swytch build, set from main.Version at startup (ldflags). The
 // cloud stream announces it — with the node id — as gRPC metadata, which is how
 // the Cloud dashboard knows each cluster's node count and running version.
@@ -943,6 +949,39 @@ func trimAncestry(fetched map[effects.Tip]*pb.Effect, eff *pb.Effect) {
 	}
 }
 
+// RepairFrontier supersedes the cloud's tip frontier for key after a walk over
+// it failed with ErrCDNBlobMissing: the frontier references ancestry whose
+// blobs are gone from cloud storage, no retry can heal it, and no normal write
+// ever consumes it (a node cannot dep-reference a chain it cannot fetch).
+// GetTips names the current frontier and the engine mints the superseding
+// snapshot; when its upload lands, the cloud consumes every frontier tip out
+// of the tips record. Returns the number of tips superseded (0 = frontier
+// already empty, nothing to repair).
+func (cs *CloudSync) RepairFrontier(ctx context.Context, key string) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, cloudBackstopTimeout)
+	defer cancel()
+	resp, err := cs.client.GetTips(ctx, &dp.GetTipsRequest{
+		AuthKey: cs.authKey,
+		Keys:    [][]byte{CloudKeyName(cs.keyNameKey, []byte(key))},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("cloud repair: get tips for %q: %w", key, err)
+	}
+	var frontier []effects.Tip
+	for _, kt := range resp.GetKeys() {
+		for _, ref := range kt.GetTips() {
+			frontier = append(frontier, effects.Tip{ref.GetNodeId(), ref.GetOffset()})
+		}
+	}
+	if len(frontier) == 0 {
+		return 0, nil
+	}
+	if err := cs.engine.RepairCloudFrontier(key, frontier); err != nil {
+		return 0, err
+	}
+	return len(frontier), nil
+}
+
 // CloudTips implements effects.CloudReader: it returns the tip frontier Cloud
 // holds for key, mapping key to its Cloud PRF image (CloudKeyName) and calling
 // GetTips — merged with the outbox's un-acked tips on the key, which are the
@@ -1183,6 +1222,9 @@ func (cs *CloudSync) fetchEffect(ctx context.Context, tip effects.Tip) (*pb.Effe
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("cdn fetch %s: %w", url, ErrCDNBlobMissing)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("cdn fetch %s: status %d", url, resp.StatusCode)
 	}

--- a/effects/effect.go
+++ b/effects/effect.go
@@ -693,6 +693,131 @@ func (e *Engine) InstallCloudTips(key string, tips []Tip, sidecar []CloudEffect)
 	return nil
 }
 
+// RepairCloudFrontier supersedes a Cloud tip frontier whose ancestry is
+// provably unreachable — a hole in the CDN blob chain that InstallCloudTips'
+// all-or-nothing walk can never get past. No normal write ever consumes such a
+// frontier: consuming a cloud tip requires dep-referencing it, and a normal
+// emit only dep-references tips it holds, so the poisoned tips would sit in
+// the cloud's tips record forever, failing every reader.
+//
+// The repair mints a state-carrying SnapshotEffect whose deps name the entire
+// broken frontier plus the local tips, then a Noop above it. Deps are just
+// refs — naming a tip requires no fetch of its bytes. Cloud-side, storing the
+// snapshot consumes every frontier tip out of the tips record; reader-side the
+// snapshot is the sole convergence point, so the walk's LCA rule stops at it
+// and the holed ancestry is never fetched again. The snapshot's state is this
+// node's local reduction of the key — whatever the hole made unreachable is
+// lost, which is the caller's adjudication to make before calling this.
+//
+// Callers must ensure no concurrent local emit on key: a sibling branch that
+// bypasses the snapshot keeps the walk's queue non-empty when the snapshot is
+// dequeued, defeating the LCA stop and re-exposing the hole.
+func (e *Engine) RepairCloudFrontier(key string, frontier []Tip) error {
+	currentSet := e.index.Contains(key)
+	var localTips []Tip
+	if currentSet != nil {
+		localTips = currentSet.Tips()
+	}
+
+	var state *pb.ReducedEffect
+	if len(localTips) > 0 {
+		result, _, err := e.reconstruct(key, localTips, "", false)
+		if err != nil {
+			return fmt.Errorf("repair %q: reduce local state: %w", key, err)
+		}
+		state = cloneReduced(result)
+	}
+	if state == nil {
+		state = &pb.ReducedEffect{}
+	}
+	// Same rationale as compaction: raw SubscriptionEffects beneath the
+	// snapshot are folded away, so the snapshot is where a future
+	// bootstrapping peer recovers the subscriber set from.
+	state.Subscribers = e.snapshotSubscribers(key)
+
+	snapEff := &pb.SnapshotEffect{
+		Collection: state.Collection,
+		State:      state,
+	}
+	for _, t := range localTips {
+		cached, err := e.getEffect(key, t)
+		if err != nil {
+			continue
+		}
+		if cached.GetSnapshot() != nil {
+			snapEff.PrevSnapshot = toPbRef(t)
+			break
+		}
+	}
+
+	deps := e.resolveTipDeps(localTips)
+	seen := make(map[Tip]struct{}, len(deps)+len(frontier))
+	for _, t := range deps {
+		seen[t] = struct{}{}
+	}
+	for _, t := range frontier {
+		if _, dup := seen[t]; !dup {
+			seen[t] = struct{}{}
+			deps = append(deps, t)
+		}
+	}
+
+	hlc := timestamppb.New(e.clock.Now())
+	snapOffset, err := e.mintLocalEffect(key, currentSet, &pb.Effect{
+		Key:            []byte(key),
+		Hlc:            hlc,
+		NodeId:         uint64(e.nodeID),
+		ForkChoiceHash: ComputeForkChoiceHash(e.nodeID, hlc),
+		Deps:           toPbRefs(deps),
+		Kind:           &pb.Effect_Snapshot{Snapshot: snapEff},
+	})
+	if err != nil {
+		return fmt.Errorf("repair %q: mint snapshot: %w", key, err)
+	}
+
+	// The tip above keeps the snapshot off the frontier: readers stop AT the
+	// snapshot, and a frontier whose sole tip is the snapshot itself is an
+	// edge nothing else exercises.
+	hlc = timestamppb.New(e.clock.Now())
+	if _, err := e.mintLocalEffect(key, e.index.Contains(key), &pb.Effect{
+		Key:            []byte(key),
+		Hlc:            hlc,
+		NodeId:         uint64(e.nodeID),
+		ForkChoiceHash: ComputeForkChoiceHash(e.nodeID, hlc),
+		Deps:           []*pb.EffectRef{toPbRef(snapOffset)},
+		Kind:           &pb.Effect_Noop{Noop: &pb.NoopEffect{}},
+	}); err != nil {
+		return fmt.Errorf("repair %q: mint tip above snapshot: %w", key, err)
+	}
+
+	slog.Warn("cloud frontier repaired: unreachable ancestry superseded by snapshot",
+		"key", key, "superseded_tips", len(frontier), "snapshot", snapOffset)
+	return nil
+}
+
+// mintLocalEffect persists a fully-built effect as a local mint: marshal,
+// offset allocation, cache install (owned), index update consuming currentSet,
+// durability hook, broadcast. The effect must already carry its key, HLC,
+// fork-choice hash, and deps.
+func (e *Engine) mintLocalEffect(key string, currentSet *keytrie.TipSet, eff *pb.Effect) (Tip, error) {
+	data, err := MarshalEffect(eff)
+	if err != nil {
+		return Tip{}, err
+	}
+	offset := e.nextOffset()
+	if e.effectCache != nil {
+		e.effectCache.PutSized(offset, eff, len(data))
+	}
+	e.updateIndex(key, currentSet, offset)
+	e.fireLocalEffect(offset, eff)
+
+	if e.broadcaster != nil {
+		notify := BuildOffsetNotify(e.nodeID, offset, eff, data, context.Background())
+		e.broadcaster.BroadcastWithData(notify, data)
+	}
+	return offset, nil
+}
+
 // fireLocalEffect invokes OnLocalEffect for a freshly-minted persisted effect.
 func (e *Engine) fireLocalEffect(offset Tip, eff *pb.Effect) {
 	e.localEffectMu.RLock()
@@ -842,20 +967,9 @@ func (e *Engine) emitSnapshot(key string, verdicts map[string]pb.Verdict) error 
 		eff.Deps = toPbRefs(e.resolveTipDeps(tips))
 	}
 
-	data, err := MarshalEffect(eff)
+	offset, err := e.mintLocalEffect(key, currentSet, eff)
 	if err != nil {
 		return err
-	}
-	offset := e.nextOffset()
-	if e.effectCache != nil {
-		e.effectCache.PutSized(offset, eff, len(data))
-	}
-	e.updateIndex(key, currentSet, offset)
-	e.fireLocalEffect(offset, eff)
-
-	if e.broadcaster != nil {
-		notify := BuildOffsetNotify(e.nodeID, offset, eff, data, context.Background())
-		e.broadcaster.BroadcastWithData(notify, data)
 	}
 
 	slog.Debug("emitSnapshot",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud membership recovery when membership data is missing or unreadable.
  * Automatically repairs inconsistent cloud membership frontiers before continuing startup.
  * Prevented concurrent membership updates from interfering with bootstrap and member removal.
  * Improved handling and reporting of missing cloud data during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->