### PR TITLE
fix removals take 2

### DIFF
--- a/beacon/beacon.go
+++ b/beacon/beacon.go
@@ -69,14 +69,6 @@ type Beacon struct {
 	removeMu     sync.Mutex
 	removeSignal chan struct{}
 
-	// membershipWriteMu serializes the startup frontier repair against
-	// applyQueuedRemovals — the only other membership writer alive during
-	// bootstrap. A removal emit racing the repair mint would land as a sibling
-	// branch bypassing the repair snapshot, and a frontier with such a branch
-	// re-exposes the unreachable ancestry to every reader (the walk only stops
-	// at a snapshot that is the sole convergence point).
-	membershipWriteMu sync.Mutex
-
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -143,8 +135,6 @@ func (b *Beacon) applyQueuedRemovals() {
 	if len(batch) == 0 {
 		return
 	}
-	b.membershipWriteMu.Lock()
-	defer b.membershipWriteMu.Unlock()
 
 	// The cloud re-offers every pending removal on each presence sweep until
 	// its TTL expires — it is zero-knowledge, so it cannot see the roster and
@@ -216,14 +206,6 @@ func (b *Beacon) Start(ctx context.Context) (err error) {
 		}
 	}()
 
-	// Cloud-pushed removals arrive as soon as the cloud stream attaches —
-	// typically while bootstrap below is still dialing — so their applier
-	// starts before Phase 1, not after.
-	if b.cfg.Cloud != nil {
-		b.wg.Add(1)
-		go b.memberRemoveLoop()
-	}
-
 	// Phase 1: peer discovery (DNS or cloud) + temporary topology + peer
 	// reachability. Does not read authoritative membership — that would
 	// deadlock when every node waits for the others before registering itself.
@@ -271,6 +253,14 @@ func (b *Beacon) Start(ctx context.Context) (err error) {
 	// not paper over here.
 	b.wg.Add(1)
 	go b.topologyLoop()
+
+	// Draining only after convergence leaves bootstrap the sole membership
+	// writer, so a removal burst can't branch alongside registerSelf. Nothing
+	// is missed meanwhile: New wires the handler, and removeQ holds the burst.
+	if b.cfg.Cloud != nil {
+		b.wg.Add(1)
+		go b.memberRemoveLoop()
+	}
 
 	slog.Info("beacon started",
 		"node_id", b.cfg.NodeID,

--- a/beacon/bootstrap.go
+++ b/beacon/bootstrap.go
@@ -123,14 +123,10 @@ func (b *Beacon) cloudCandidates(ctx context.Context) []string {
 }
 
 // repairMembershipFrontier is the one-shot startup repair for a cloud
-// membership frontier whose ancestry is provably holed. Held under
-// membershipWriteMu so a cloud-pushed removal burst can't emit a sibling
-// branch while the repair snapshot is being minted.
+// membership frontier whose ancestry is provably holed.
 func (b *Beacon) repairMembershipFrontier(ctx context.Context, cause error) {
 	slog.Warn("beacon: cloud membership frontier is unreadable, repairing with a superseding snapshot",
 		"error", cause)
-	b.membershipWriteMu.Lock()
-	defer b.membershipWriteMu.Unlock()
 	superseded, err := b.cfg.Cloud.RepairFrontier(ctx, MembershipKey)
 	if err != nil {
 		slog.Error("beacon: membership frontier repair failed, starting solo unrepaired", "error", err)
@@ -163,6 +159,11 @@ func (b *Beacon) discoverMembersWithRetry(ctx context.Context) (*pb.ReducedEffec
 		attemptCancel()
 		if err == nil {
 			return reduced, nil
+		}
+		// A hole is durable: every retry re-pays the fetch to learn the same
+		// answer, and only the caller's repair resolves it.
+		if errors.Is(err, effects.ErrCDNBlobMissing) {
+			return nil, err
 		}
 		slog.Debug("beacon: cloud member discovery failed, retrying", "error", err, "backoff", backoff)
 

--- a/cluster/fetch_order_test.go
+++ b/cluster/fetch_order_test.go
@@ -116,6 +116,42 @@ func TestFetchFromAnyPreferCDNFallsBackToPeers(t *testing.T) {
 	}
 }
 
+// TestFetchFromAnyPreferCDNMissSkipsPeerLeg: a definite 404 under PreferCDN is
+// cloud's authoritative answer for a key no peer's filter claims, so the fetch
+// must surface the sentinel immediately rather than spend the peer leg's
+// timeout — the caller repairs the frontier on it, and that has to happen
+// inside the client's deadline.
+func TestFetchFromAnyPreferCDNMissSkipsPeerLeg(t *testing.T) {
+	pm := newFetchTestPM(t)
+	cdn := &recordingCDN{err: effects.ErrCDNBlobMissing}
+	pm.SetCDNFetcher(cdn)
+
+	_, err := pm.FetchFromAny(&pb.EffectRef{NodeId: 1, Offset: 1}, effects.PreferCDN)
+	if !errors.Is(err, effects.ErrCDNBlobMissing) {
+		t.Fatalf("want the CDN-missing sentinel surfaced, got: %v", err)
+	}
+	if cdn.callCount() != 1 {
+		t.Fatalf("CDN called %d times, want exactly 1", cdn.callCount())
+	}
+}
+
+// TestFetchFromAnyPreferPeersMissStillTriesCDN: the skip is scoped to
+// PreferCDN. Under PreferPeers some peer's filter claims the key, so a CDN
+// miss must not short-circuit the peer leg that might actually hold it.
+func TestFetchFromAnyPreferPeersMissStillTriesCDN(t *testing.T) {
+	pm := newFetchTestPM(t)
+	cdn := &recordingCDN{err: effects.ErrCDNBlobMissing}
+	pm.SetCDNFetcher(cdn)
+
+	_, err := pm.FetchFromAny(&pb.EffectRef{NodeId: 1, Offset: 1}, effects.PreferPeers)
+	if err == nil {
+		t.Fatal("expected an error when both peers and CDN fail")
+	}
+	if cdn.callCount() != 1 {
+		t.Fatalf("CDN called %d times, want the fallback to have run once", cdn.callCount())
+	}
+}
+
 func TestFetchFromAnyNoCDNFetcherPeersOnly(t *testing.T) {
 	pm := newFetchTestPM(t)
 

--- a/cluster/peer_manager.go
+++ b/cluster/peer_manager.go
@@ -22,6 +22,7 @@ package cluster
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -546,6 +547,12 @@ func (pm *PeerManager) FetchFromAny(offset *pb.EffectRef, hint effects.FetchHint
 	data, err := first()
 	if err == nil && len(data) > 0 {
 		return data, nil
+	}
+	// A 404 is cloud answering, not cloud failing, and PreferCDN means every
+	// peer's filter already disclaimed this key — the fallback would spend its
+	// full 10s re-asking nodes that said no.
+	if hint == effects.PreferCDN && errors.Is(err, effects.ErrCDNBlobMissing) {
+		return nil, err
 	}
 	fallbackData, fallbackErr := second()
 	if fallbackErr == nil && len(fallbackData) > 0 {

--- a/effects/effect.go
+++ b/effects/effect.go
@@ -102,12 +102,6 @@ type Engine struct {
 	broadcaster Broadcaster // nil for standalone
 	cloudReader CloudReader // nil when no cloud is configured (standalone/dev)
 
-	// repairMu serializes RepairCloudFrontier engine-wide: two concurrent
-	// repairs on the same key would mint sibling snapshots, and a sibling
-	// branch bypassing a snapshot keeps the walk's queue non-empty when the
-	// snapshot is dequeued, defeating the LCA stop that hides the hole.
-	repairMu sync.Mutex
-
 	nodeID pb.NodeID
 	clock  *crdt.HLC
 
@@ -680,13 +674,10 @@ func (e *Engine) hydrateFromCloud(key string) (installed, consulted bool, err er
 // subsequent read reconstruct partial state as if it were the whole answer.
 // Unlike retryBootstrap's walkAndInstall, which is deliberately progressive.
 //
-// The one exception is a durable hole: a tip whose walk fails with
-// ErrCDNBlobMissing sits above ancestry provably gone from cloud storage.
-// Retrying can never heal it and no normal write ever consumes it (an emit
-// only dep-references chains it holds), so failing here would fail every
-// read and reconcile of the key forever. Instead the frontier is repaired:
-// the walkable tips' state is preserved in a superseding snapshot and the
-// holed tips are dep-named so the cloud consumes them out of its tips record.
+// A tip failing with ErrCDNBlobMissing is the exception: nothing heals it —
+// retries re-fetch a blob that is gone, and no write consumes it, since an emit
+// can only dep-reference chains it holds — so returning an error would fail
+// every read and reconcile of the key forever. Repair instead.
 func (e *Engine) InstallCloudTips(key string, tips []Tip, sidecar []CloudEffect) error {
 	// Warm the cache with the closure effects GetTips delivered inline, so the
 	// walk below runs locally instead of one WAN fetch per dep (n+1). Same
@@ -720,11 +711,9 @@ func (e *Engine) InstallCloudTips(key string, tips []Tip, sidecar []CloudEffect)
 		e.installTips(key, tips)
 		return nil
 	}
-	// The readable tips ride into the repair un-installed: installing them
-	// first and then failing the repair would leave partial state posing as
-	// the whole answer. The repair reduces their chains into the snapshot's
-	// state and dep-names them, so their data survives the supersede and the
-	// cloud consumes them together with the holed tips.
+	// Readable tips stay un-installed until the repair folds them into the
+	// snapshot: installing them first and then failing would leave partial
+	// state posing as the whole answer.
 	return e.RepairCloudFrontier(key, readable, holed)
 }
 
@@ -749,12 +738,17 @@ func (e *Engine) InstallCloudTips(key string, tips []Tip, sidecar []CloudEffect)
 // hole is lost, which is the caller's adjudication to make before calling
 // this.
 //
-// Callers must ensure no concurrent local emit on key: a sibling branch that
-// bypasses the snapshot keeps the walk's queue non-empty when the snapshot is
-// dequeued, defeating the LCA stop and re-exposing the hole.
+// A concurrent emit lands as a sibling of the snapshot rather than beneath it,
+// which keeps the walk's queue non-empty at the snapshot and re-exposes the
+// hole. The next walk fails with ErrCDNBlobMissing and repairs again, so this
+// converges rather than needing exclusion.
 func (e *Engine) RepairCloudFrontier(key string, readable, holed []Tip) error {
-	e.repairMu.Lock()
-	defer e.repairMu.Unlock()
+	// This mint becomes cloud's answer for the key, so the node making it must
+	// be a holder peers will route writes to. Subscribing first also keeps the
+	// SubscriptionEffect in the ancestry the snapshot folds up, not beside it.
+	if err := e.ensureSubscribed(key); err != nil {
+		return fmt.Errorf("repair %q: subscribe: %w", key, err)
+	}
 
 	currentSet := e.index.Contains(key)
 	var localTips []Tip
@@ -798,10 +792,17 @@ func (e *Engine) RepairCloudFrontier(key string, readable, holed []Tip) error {
 	if state == nil {
 		state = &pb.ReducedEffect{}
 	}
-	// Same rationale as compaction: raw SubscriptionEffects beneath the
-	// snapshot are folded away, so the snapshot is where a future
-	// bootstrapping peer recovers the subscriber set from.
-	state.Subscribers = e.snapshotSubscribers(key)
+	// A bootstrapping peer stops at this snapshot and never sees the
+	// SubscriptionEffects beneath it, so the stamp is the only surviving record
+	// of who holds the key. Self is absent from the leaf set by design
+	// (addPeerSubscriber drops it) yet has to appear here — otherwise peers
+	// reconstruct a subscriber set missing the node holding the state.
+	subs := e.snapshotSubscribers(key)
+	if subs == nil {
+		subs = make(map[uint64]bool, 1)
+	}
+	subs[uint64(e.nodeID)] = true
+	state.Subscribers = subs
 
 	snapEff := &pb.SnapshotEffect{
 		Collection: state.Collection,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup synchronization so member removals are safely queued until membership is ready.
  * Cloud membership repair now preserves node information and handles concurrent updates more reliably.
  * Missing CDN data is reported immediately when CDN retrieval is preferred, avoiding unnecessary peer requests.
  * Peer-preferred retrieval continues to use peer fallback when CDN data is unavailable.
  * Improved recovery from incomplete or unavailable cloud membership data during bootstrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->