### PR TITLE
fix casing on acls

### DIFF
--- a/redis/acl.go
+++ b/redis/acl.go
@@ -521,37 +521,41 @@ func (m *ACLManager) applyACLRules(user *shared.ACLUser, rules []string) error {
 	return nil
 }
 
-// applyACLRule applies a single ACL rule to a user
+// applyACLRule applies a single ACL rule to a user. Rule keywords
+// (on/off/nopass/allkeys/+@cat/+cmd/... and the ~ % & prefixes) are
+// case-insensitive, matched against a lowercased copy, but everything
+// after a >, #, <, ! prefix is case-sensitive payload (password, hash)
+// and must come from the original rule string, not the lowercased copy.
 func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
-	rule = strings.ToLower(rule)
+	lower := strings.ToLower(rule)
 
 	switch {
-	case rule == "on":
+	case lower == "on":
 		user.Enabled = true
-	case rule == "off":
+	case lower == "off":
 		user.Enabled = false
-	case rule == "nopass":
+	case lower == "nopass":
 		user.NoPass = true
-	case rule == "resetpass":
+	case lower == "resetpass":
 		user.PasswordHashes = nil
 		user.NoPass = false
-	case rule == "allkeys" || rule == "~*":
+	case lower == "allkeys" || lower == "~*":
 		user.AllKeys = true
-	case rule == "resetkeys":
+	case lower == "resetkeys":
 		user.AllKeys = false
 		user.KeyPatterns = nil
-	case rule == "allchannels" || rule == "&*":
+	case lower == "allchannels" || lower == "&*":
 		user.AllChannels = true
-	case rule == "resetchannels":
+	case lower == "resetchannels":
 		user.AllChannels = false
 		user.ChannelPatterns = nil
-	case rule == "allcommands" || rule == "+@all":
+	case lower == "allcommands" || lower == "+@all":
 		user.AllCommands = true
-	case rule == "nocommands" || rule == "-@all":
+	case lower == "nocommands" || lower == "-@all":
 		user.AllCommands = false
 		user.Categories = make(map[shared.CommandCategory]bool)
 		user.Commands = make(map[shared.CommandType]bool)
-	case rule == "reset":
+	case lower == "reset":
 		// Reset to minimal state
 		user.Enabled = false
 		user.NoPass = false
@@ -565,8 +569,8 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 		user.ChannelPatterns = nil
 		user.Selectors = nil
 
-	case strings.HasPrefix(rule, ">"):
-		// Plaintext password - hash it
+	case strings.HasPrefix(lower, ">"):
+		// Plaintext password - hash it (case-sensitive payload)
 		password := rule[1:]
 		hash, err := HashPassword(password)
 		if err != nil {
@@ -575,14 +579,14 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 		user.PasswordHashes = append(user.PasswordHashes, hash)
 		user.NoPass = false
 
-	case strings.HasPrefix(rule, "#"):
-		// Pre-hashed password (bcrypt format)
+	case strings.HasPrefix(lower, "#"):
+		// Pre-hashed password (bcrypt format, case-sensitive payload)
 		hashStr := rule[1:]
 		user.PasswordHashes = append(user.PasswordHashes, []byte(hashStr))
 		user.NoPass = false
 
-	case strings.HasPrefix(rule, "<"):
-		// Remove password
+	case strings.HasPrefix(lower, "<"):
+		// Remove password (case-sensitive payload)
 		password := rule[1:]
 		newHashes := user.PasswordHashes[:0]
 		for _, hash := range user.PasswordHashes {
@@ -592,8 +596,8 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 		}
 		user.PasswordHashes = newHashes
 
-	case strings.HasPrefix(rule, "!"):
-		// Remove hashed password
+	case strings.HasPrefix(lower, "!"):
+		// Remove hashed password (case-sensitive payload)
 		hashStr := rule[1:]
 		newHashes := user.PasswordHashes[:0]
 		for _, hash := range user.PasswordHashes {
@@ -603,7 +607,7 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 		}
 		user.PasswordHashes = newHashes
 
-	case strings.HasPrefix(rule, "+@"):
+	case strings.HasPrefix(lower, "+@"):
 		// Add category
 		catName := rule[2:]
 		cat, ok := shared.GetCategoryByName(catName)
@@ -616,7 +620,7 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 			user.Categories[cat] = true
 		}
 
-	case strings.HasPrefix(rule, "-@"):
+	case strings.HasPrefix(lower, "-@"):
 		// Remove category
 		catName := rule[2:]
 		cat, ok := shared.GetCategoryByName(catName)
@@ -629,7 +633,7 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 			user.Categories[cat] = false
 		}
 
-	case strings.HasPrefix(rule, "+"):
+	case strings.HasPrefix(lower, "+"):
 		// Add command (may include |subcommand)
 		cmdStr := rule[1:]
 		if idx := strings.Index(cmdStr, "|"); idx > 0 {
@@ -643,7 +647,7 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 			if user.Subcommands[cmd] == nil {
 				user.Subcommands[cmd] = make(map[string]bool)
 			}
-			user.Subcommands[cmd][subName] = true
+			user.Subcommands[cmd][strings.ToLower(subName)] = true
 		} else {
 			cmd, ok := shared.LookupCommandName(strings.ToUpper(cmdStr))
 			if !ok {
@@ -652,7 +656,7 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 			user.Commands[cmd] = true
 		}
 
-	case strings.HasPrefix(rule, "-"):
+	case strings.HasPrefix(lower, "-"):
 		// Remove command
 		cmdStr := rule[1:]
 		if idx := strings.Index(cmdStr, "|"); idx > 0 {
@@ -665,7 +669,7 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 			if user.Subcommands[cmd] == nil {
 				user.Subcommands[cmd] = make(map[string]bool)
 			}
-			user.Subcommands[cmd][subName] = false
+			user.Subcommands[cmd][strings.ToLower(subName)] = false
 		} else {
 			cmd, ok := shared.LookupCommandName(strings.ToUpper(cmdStr))
 			if !ok {
@@ -674,32 +678,32 @@ func (m *ACLManager) applyACLRule(user *shared.ACLUser, rule string) error {
 			user.Commands[cmd] = false
 		}
 
-	case strings.HasPrefix(rule, "~"):
-		// Key pattern (read/write)
+	case strings.HasPrefix(lower, "~"):
+		// Key pattern (read/write, case-sensitive)
 		pattern := rule[1:]
 		user.KeyPatterns = append(user.KeyPatterns, shared.KeyPattern{
 			Pattern: pattern,
 			Type:    shared.KeyPatternReadWrite,
 		})
 
-	case strings.HasPrefix(rule, "%r~"):
-		// Key pattern (read only)
+	case strings.HasPrefix(lower, "%r~"):
+		// Key pattern (read only, case-sensitive)
 		pattern := rule[3:]
 		user.KeyPatterns = append(user.KeyPatterns, shared.KeyPattern{
 			Pattern: pattern,
 			Type:    shared.KeyPatternReadOnly,
 		})
 
-	case strings.HasPrefix(rule, "%w~"):
-		// Key pattern (write only)
+	case strings.HasPrefix(lower, "%w~"):
+		// Key pattern (write only, case-sensitive)
 		pattern := rule[3:]
 		user.KeyPatterns = append(user.KeyPatterns, shared.KeyPattern{
 			Pattern: pattern,
 			Type:    shared.KeyPatternWriteOnly,
 		})
 
-	case strings.HasPrefix(rule, "&"):
-		// Channel pattern
+	case strings.HasPrefix(lower, "&"):
+		// Channel pattern (case-sensitive)
 		pattern := rule[1:]
 		if pattern == "*" {
 			user.AllChannels = true

--- a/redis/acl_test.go
+++ b/redis/acl_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/swytchdb/swytch/redis/shared"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestACLManager_DefaultUser(t *testing.T) {
@@ -609,5 +610,143 @@ func TestHandler_CommandACL(t *testing.T) {
 	h.ExecuteInto(cmd, w, conn)
 	if !bytes.Contains(buf.Bytes(), []byte("NOPERM")) {
 		t.Errorf("FLUSHDB should be denied, got %s", buf.String())
+	}
+}
+
+func TestACLManager_RuleCaseSensitivity_AclFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	aclFile := filepath.Join(tmpDir, "acl.conf")
+
+	content := "user demo on >MixedCasePw ~KeyPattern:* &*\n"
+	if err := os.WriteFile(aclFile, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write ACL file: %v", err)
+	}
+
+	m := NewACLManager()
+	if err := m.LoadFromFile(aclFile); err != nil {
+		t.Fatalf("failed to load ACL file: %v", err)
+	}
+
+	// Original-case password should authenticate.
+	if _, err := m.Authenticate("demo", "MixedCasePw"); err != nil {
+		t.Errorf("should authenticate with original-case password: %v", err)
+	}
+
+	// Lowercased password must NOT authenticate - the bug lowercased
+	// the plaintext before hashing it.
+	if _, err := m.Authenticate("demo", "mixedcasepw"); err == nil {
+		t.Error("lowercased password should not authenticate")
+	}
+
+	// Key pattern must retain its original case.
+	demo := m.GetUser("demo")
+	if len(demo.KeyPatterns) != 1 || demo.KeyPatterns[0].Pattern != "KeyPattern:*" {
+		t.Errorf("key pattern should retain original case, got %+v", demo.KeyPatterns)
+	}
+}
+
+func TestACLManager_RuleCaseSensitivity_SetUser(t *testing.T) {
+	h := NewHandler(HandlerConfig{})
+	defer h.Close()
+
+	conn := &shared.Connection{
+		User: testUser,
+		Ctx:  context.Background(),
+	}
+
+	buf := &bytes.Buffer{}
+	w := shared.NewWriter(buf)
+
+	cmd := &shared.Command{Type: shared.CmdAcl, Args: [][]byte{
+		[]byte("SETUSER"), []byte("mixeduser"), []byte("on"), []byte(">MixedCasePw"), []byte("~KeyPattern:*"),
+	}}
+	h.ExecuteInto(cmd, w, conn)
+	if !bytes.Contains(buf.Bytes(), []byte("+OK")) {
+		t.Fatalf("ACL SETUSER should return OK, got %s", buf.String())
+	}
+
+	if _, err := h.aclManager.Authenticate("mixeduser", "MixedCasePw"); err != nil {
+		t.Errorf("should authenticate with original-case password: %v", err)
+	}
+	if _, err := h.aclManager.Authenticate("mixeduser", "mixedcasepw"); err == nil {
+		t.Error("lowercased password should not authenticate")
+	}
+
+	user := h.aclManager.GetUser("mixeduser")
+	if len(user.KeyPatterns) != 1 || user.KeyPatterns[0].Pattern != "KeyPattern:*" {
+		t.Errorf("key pattern should retain original case, got %+v", user.KeyPatterns)
+	}
+}
+
+func TestACLManager_RuleCaseSensitivity_KeyPatternMatching(t *testing.T) {
+	m := NewACLManager()
+	user := &shared.ACLUser{
+		Name:        "app",
+		Enabled:     true,
+		Categories:  make(map[shared.CommandCategory]bool),
+		Commands:    make(map[shared.CommandType]bool),
+		Subcommands: make(map[shared.CommandType]map[string]bool),
+	}
+	m.SetUser(user)
+
+	if err := m.applyACLRules(user, []string{"~KeyPattern:*"}); err != nil {
+		t.Fatalf("failed to apply rules: %v", err)
+	}
+
+	if err := m.CheckKey(user, "KeyPattern:1", false); err != nil {
+		t.Errorf("should allow access to KeyPattern:1: %v", err)
+	}
+	if err := m.CheckKey(user, "keypattern:1", false); err == nil {
+		t.Error("should deny access to keypattern:1 (pattern is case-sensitive)")
+	}
+}
+
+func TestACLManager_RuleCaseSensitivity_HashedPassword(t *testing.T) {
+	rawHash, err := bcrypt.GenerateFromPassword([]byte("secretPW"), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to generate bcrypt hash: %v", err)
+	}
+
+	m := NewACLManager()
+	user := &shared.ACLUser{
+		Name:        "hashed",
+		Categories:  make(map[shared.CommandCategory]bool),
+		Commands:    make(map[shared.CommandType]bool),
+		Subcommands: make(map[shared.CommandType]map[string]bool),
+	}
+	m.SetUser(user)
+
+	rule := "on #" + string(rawHash)
+	if err := m.applyACLRules(user, strings.Fields(rule)); err != nil {
+		t.Fatalf("failed to apply rules: %v", err)
+	}
+
+	if len(user.PasswordHashes) != 1 || string(user.PasswordHashes[0]) != string(rawHash) {
+		t.Errorf("hash should be stored verbatim, got %q want %q", user.PasswordHashes[0], rawHash)
+	}
+
+	if _, err := m.Authenticate("hashed", "secretPW"); err != nil {
+		t.Errorf("should authenticate with original password against verbatim hash: %v", err)
+	}
+}
+
+func TestACLManager_RuleCaseSensitivity_KeywordsStillCaseInsensitive(t *testing.T) {
+	m := NewACLManager()
+	if err := m.parseACLLine("user x ON NOPASS ALLKEYS"); err != nil {
+		t.Fatalf("failed to parse uppercase keywords: %v", err)
+	}
+
+	user := m.GetUser("x")
+	if user == nil {
+		t.Fatal("user x should have been created")
+	}
+	if !user.Enabled {
+		t.Error("ON keyword should enable the user regardless of case")
+	}
+	if !user.NoPass {
+		t.Error("NOPASS keyword should be honored regardless of case")
+	}
+	if !user.AllKeys {
+		t.Error("ALLKEYS keyword should be honored regardless of case")
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ACL keywords, commands, categories, and subcommands are now handled consistently regardless of letter casing.
  - Passwords, hashes, key patterns, and channel patterns preserve their intended case sensitivity.
  - ACL rules now correctly match case-sensitive keys and retain hashed passwords exactly as provided.

- **Tests**
  - Added coverage for case handling in ACL files and `SETUSER` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->